### PR TITLE
BG3 Mod Manager Redux UI foundation checkpoint

### DIFF
--- a/src/Core/Models/DivinityModData.cs
+++ b/src/Core/Models/DivinityModData.cs
@@ -202,6 +202,8 @@ public class DivinityModData : DivinityBaseModData, ISelectable
 	[ObservableAsProperty] public string OsirisStatusToolTipText { get; }
 	[ObservableAsProperty] public string LastModifiedDateText { get; }
 	[ObservableAsProperty] public string DisplayVersion { get; }
+	[ObservableAsProperty] public DateTime? DisplayLastUpdated { get; }
+	[ObservableAsProperty] public string DisplaySource { get; }
 
 	[ObservableAsProperty] public Visibility DependencyVisibility { get; }
 	[ObservableAsProperty] public Visibility ConflictsVisibility { get; }
@@ -412,6 +414,10 @@ public class DivinityModData : DivinityBaseModData, ISelectable
 			.Select(DateUtils.UnixTimeStampToDateTime)
 			.ToUIProperty(this, x => x.NexusModsUpdatedDate);
 
+		this.WhenAnyValue(x => x.NexusModsData.UpdatedTimestamp, x => x.LastUpdated)
+			.Select(x => x.Item1 > 0 ? (DateTime?)DateUtils.UnixTimeStampToDateTime(x.Item1) : x.Item2)
+			.ToUIProperty(this, x => x.DisplayLastUpdated);
+
 		this.WhenAnyValue(x => x.NexusModsCreatedDate, x => x.NexusModsUpdatedDate, x => x.NexusModsData.EndorsementCount)
 			.Select(x => NexusModsInfoToTooltip(x.Item1, x.Item2, x.Item3))
 			.ToUIProperty(this, x => x.NexusModsTooltipInfo);
@@ -426,6 +432,12 @@ public class DivinityModData : DivinityBaseModData, ISelectable
 		this.WhenAnyValue(x => x.CanOpenNexusModsLink)
 			.Select(b => b ? Visibility.Visible : Visibility.Collapsed)
 			.ToUIProperty(this, x => x.OpenNexusModsLinkVisibility, Visibility.Collapsed);
+
+		// This is presentation metadata only. mod.io will join this resolver when
+		// its provider is added; it does not affect the installed mod or load order.
+		this.WhenAnyValue(x => x.CanOpenNexusModsLink)
+			.Select(isNexusLinked => isNexusLinked ? "Nexus Mods" : "Local")
+			.ToUIProperty(this, x => x.DisplaySource, "Local");
 
 		var depConn = Dependencies.Connect().ObserveOn(RxApp.MainThreadScheduler);
 		depConn.SortAndBind(out displayedDependencies, _moduleSort).DisposeMany().Subscribe();

--- a/src/Core/Models/DivinityModManagerSettings.cs
+++ b/src/Core/Models/DivinityModManagerSettings.cs
@@ -27,7 +27,9 @@ public class DivinityModManagerSettings : ReactiveObject
 	[DataMember, Reactive] public bool LaunchDX11 { get; set; }
 
 	[DefaultValue("")]
-	[SettingsEntry("NexusMods API Key", "Your personal NexusMods API key, which will allow the mod manager to fetch mod updates/information", HideFromUI = true)]
+	// REDUX RELEASE BLOCKER: Before public release, register with Nexus Mods, obtain an SSO application slug,
+	// replace the personal API key testing flow with browser SSO, and re-review API usage/rate limits.
+	[SettingsEntry("Nexus Mods API Key", "Personal API key used to retrieve Nexus Mods metadata and updates. This testing build stores the key locally in Data/settings.json. You can revoke the key from your Nexus Mods account at any time.")]
 	[DataMember, Reactive] public string NexusModsAPIKey { get; set; }
 
 	[DefaultValue(false)]
@@ -82,6 +84,23 @@ public class DivinityModManagerSettings : ReactiveObject
 
 	[DefaultValue(true)]
 	[DataMember, Reactive] public bool DarkThemeEnabled { get; set; }
+
+	// Redux mod-list column choices. These are managed from the column-header
+	// context menu, so they stay out of the main Settings window.
+	[DefaultValue(true)]
+	[DataMember, Reactive] public bool ShowModListVersionColumn { get; set; }
+
+	[DefaultValue(true)]
+	[DataMember, Reactive] public bool ShowModListAuthorColumn { get; set; }
+
+	[DefaultValue(true)]
+	[DataMember, Reactive] public bool ShowModListLastUpdatedColumn { get; set; }
+
+	[DefaultValue(true)]
+	[DataMember, Reactive] public bool ShowModListLastModifiedColumn { get; set; }
+
+	[DefaultValue(true)]
+	[DataMember, Reactive] public bool ShowModListSourceColumn { get; set; }
 
 	[DefaultValue(true)]
 	[SettingsEntry("Shift Focus on Swap", "When moving selected mods to the opposite list with Enter, move focus to that list as well")]

--- a/src/Core/Models/NexusMods/NexusModsModData.cs
+++ b/src/Core/Models/NexusMods/NexusModsModData.cs
@@ -5,6 +5,7 @@ using NexusModsNET.DataModels;
 
 using System.ComponentModel;
 using System.Reflection;
+using System.Text;
 
 namespace DivinityModManager.Models.NexusMods;
 
@@ -35,8 +36,60 @@ public class NexusModsModData : INotifyPropertyChanged
 	[JsonProperty("summary")]
 	public string Summary { get; set; }
 
-	//[JsonProperty("description")]
-	//public string Description { get; set; }
+	[JsonProperty("description")]
+	public string Description { get; set; }
+
+	[JsonProperty("description_loaded")]
+	public bool DescriptionLoaded { get; set; }
+
+	private Dictionary<string, List<string>> _changelogs = new();
+
+	[JsonProperty("changelogs")]
+	public Dictionary<string, List<string>> Changelogs
+	{
+		get => _changelogs;
+		set
+		{
+			_changelogs = value ?? new Dictionary<string, List<string>>();
+			RaisePropertyChanged(nameof(Changelogs));
+			RaisePropertyChanged(nameof(ChangelogText));
+		}
+	}
+
+	[JsonProperty("changelogs_loaded")]
+	public bool ChangelogsLoaded { get; set; }
+
+	[JsonIgnore]
+	public string ChangelogText
+	{
+		get
+		{
+			if (Changelogs == null || Changelogs.Count == 0)
+			{
+				return String.Empty;
+			}
+
+			var text = new StringBuilder();
+			foreach (var changelog in Changelogs)
+			{
+				if (text.Length > 0)
+				{
+					text.AppendLine();
+				}
+
+				text.Append("Version ").AppendLine(changelog.Key);
+				foreach (var entry in changelog.Value ?? Enumerable.Empty<string>())
+				{
+					if (!String.IsNullOrWhiteSpace(entry))
+					{
+						text.Append("\u2022 ").AppendLine(entry.Trim());
+					}
+				}
+			}
+
+			return text.ToString().Trim();
+		}
+	}
 
 	[JsonProperty("picture_url")]
 	public Uri PictureUrl { get; set; }
@@ -100,6 +153,16 @@ public class NexusModsModData : INotifyPropertyChanged
 		}
 	}
 
+	public void SetChangelogs(Dictionary<string, IEnumerable<string>> changelogs)
+	{
+		Changelogs = changelogs?.ToDictionary(
+			entry => entry.Key,
+			entry => entry.Value?.Where(value => !String.IsNullOrWhiteSpace(value)).ToList() ?? new List<string>())
+			?? new Dictionary<string, List<string>>();
+		ChangelogsLoaded = true;
+		RaisePropertyChanged(nameof(ChangelogsLoaded));
+	}
+
 	private static readonly IEnumerable<PropertyInfo> _lazySerializedProperties = typeof(NexusModsModData)
 		.GetProperties(BindingFlags.Public | BindingFlags.Instance)
 		.Where(prop => prop.GetCustomAttribute<JsonPropertyAttribute>(true) != null);
@@ -135,6 +198,8 @@ public class NexusModsModData : INotifyPropertyChanged
 				}
 			}
 		}
+		DescriptionLoaded = true;
+		RaisePropertyChanged(nameof(DescriptionLoaded));
 		IsUpdated = true;
 		RaisePropertyChanged(nameof(IsUpdated));
 	}

--- a/src/Core/Util/DivinityGlobalCommands.cs
+++ b/src/Core/Util/DivinityGlobalCommands.cs
@@ -26,6 +26,8 @@ public class DivinityGlobalCommands : ReactiveObject
 	public ReactiveCommand<DivinityModData, Unit> ToggleNameDisplayCommand { get; private set; }
 	public ReactiveCommand<string, Unit> CopyToClipboardCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> DeleteModCommand { get; private set; }
+	public ReactiveCommand<DivinityModData, Unit> MoveModToActiveCommand { get; private set; }
+	public ReactiveCommand<DivinityModData, Unit> MoveModToInactiveCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> OpenNexusModsPageCommand { get; private set; }
 	public ReactiveCommand<string, Unit> OpenURLCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> ToggleForceAllowInLoadOrderCommand { get; private set; }
@@ -129,6 +131,44 @@ public class DivinityGlobalCommands : ReactiveObject
 		_viewModel.ClearMissingMods();
 	}
 
+	private void MoveModsBetweenLists(DivinityModData contextMod, bool moveToActive)
+	{
+		if (contextMod == null || _viewModel == null)
+		{
+			return;
+		}
+
+		var modsToMove = contextMod.IsSelected
+			? _viewModel.Mods.Where(mod => mod.IsSelected
+				&& mod.CanAddToLoadOrder
+				&& mod.IsActive != moveToActive).ToList()
+			: new List<DivinityModData> { contextMod };
+
+		modsToMove = modsToMove
+			.Where(mod => mod.CanAddToLoadOrder && mod.IsActive != moveToActive)
+			.ToList();
+		if (modsToMove.Count == 0)
+		{
+			return;
+		}
+
+		foreach (var mod in modsToMove)
+		{
+			if (moveToActive)
+			{
+				_viewModel.AddActiveMod(mod);
+			}
+			else
+			{
+				_viewModel.RemoveActiveMod(mod);
+			}
+		}
+
+		var targetName = moveToActive ? "active" : "inactive";
+		var modLabel = modsToMove.Count == 1 ? "mod" : "mods";
+		_viewModel.ShowAlert($"Moved {modsToMove.Count} {modLabel} to the {targetName} mods list.", AlertType.Info, 10);
+	}
+
 	public DivinityGlobalCommands()
 	{
 		var canExecuteViewModelCommands = this.WhenAnyValue(x => x.ViewModel, x => x.ViewModel.IsLocked, (vm, b) => vm != null && !b);
@@ -159,6 +199,11 @@ public class DivinityGlobalCommands : ReactiveObject
 				_viewModel.DeleteMod(mod);
 			}
 		}, canExecuteViewModelCommands);
+
+		MoveModToActiveCommand = ReactiveCommand.Create<DivinityModData>(
+			mod => MoveModsBetweenLists(mod, true), canExecuteViewModelCommands);
+		MoveModToInactiveCommand = ReactiveCommand.Create<DivinityModData>(
+			mod => MoveModsBetweenLists(mod, false), canExecuteViewModelCommands);
 
 		OpenURLCommand = ReactiveCommand.Create<string>(OpenURL, canExecuteViewModelCommands);
 		OpenNexusModsPageCommand = ReactiveCommand.Create<DivinityModData>(OpenNexusModsPage, canExecuteViewModelCommands);

--- a/src/Core/Util/DivinityGlobalCommands.cs
+++ b/src/Core/Util/DivinityGlobalCommands.cs
@@ -29,6 +29,7 @@ public class DivinityGlobalCommands : ReactiveObject
 	public ReactiveCommand<DivinityModData, Unit> MoveModToActiveCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> MoveModToInactiveCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> OpenNexusModsPageCommand { get; private set; }
+	public ReactiveCommand<DivinityModData, Unit> OpenNexusModsChangelogPageCommand { get; private set; }
 	public ReactiveCommand<string, Unit> OpenURLCommand { get; private set; }
 	public ReactiveCommand<DivinityModData, Unit> ToggleForceAllowInLoadOrderCommand { get; private set; }
 
@@ -98,6 +99,15 @@ public class DivinityGlobalCommands : ReactiveObject
 		if (!String.IsNullOrEmpty(url))
 		{
 			ProcessHelper.TryOpenUrl(url);
+		}
+	}
+
+	public void OpenNexusModsChangelogPage(DivinityModData mod)
+	{
+		var url = mod.GetURL(ModSourceType.NEXUSMODS);
+		if (!String.IsNullOrEmpty(url))
+		{
+			ProcessHelper.TryOpenUrl($"{url}?tab=logs");
 		}
 	}
 
@@ -207,6 +217,7 @@ public class DivinityGlobalCommands : ReactiveObject
 
 		OpenURLCommand = ReactiveCommand.Create<string>(OpenURL, canExecuteViewModelCommands);
 		OpenNexusModsPageCommand = ReactiveCommand.Create<DivinityModData>(OpenNexusModsPage, canExecuteViewModelCommands);
+		OpenNexusModsChangelogPageCommand = ReactiveCommand.Create<DivinityModData>(OpenNexusModsChangelogPage, canExecuteViewModelCommands);
 		ToggleForceAllowInLoadOrderCommand = ReactiveCommand.Create<DivinityModData>(ToggleForceAllowInLoadOrder, canExecuteViewModelCommands);
 	}
 }

--- a/src/Core/Util/NexusModsDataLoader.cs
+++ b/src/Core/Util/NexusModsDataLoader.cs
@@ -124,7 +124,9 @@ public static class NexusModsDataLoader
 				OnTaskDone();
 				return links;
 			}
-			using var dataLoader = new InfosInquirer(_client);
+			// InfosInquirer.Dispose also disposes the shared API client. The loader owns
+			// that client lifetime, so keep the inquirer alive for this request only.
+			var dataLoader = new InfosInquirer(_client);
 			foreach (var mod in mods)
 			{
 				if (mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START)
@@ -203,7 +205,9 @@ public static class NexusModsDataLoader
 
 			DivinityApp.Log($"Using NexusMods API to update {total} mods");
 
-			using var dataLoader = new InfosInquirer(_client);
+			// InfosInquirer.Dispose also disposes the shared API client. The loader owns
+			// that client lifetime, so a following changelog request can reuse it safely.
+			var dataLoader = new InfosInquirer(_client);
 			foreach (var mod in targetMods)
 			{
 				var result = await dataLoader.Mods.GetMod(DivinityApp.NEXUSMODS_GAME_DOMAIN, mod.NexusModsData.ModId, t);
@@ -225,5 +229,61 @@ public static class NexusModsDataLoader
 		OnTaskDone();
 
 		return taskResult;
+	}
+
+	public static async Task<bool> LoadChangelogsAsync(IEnumerable<DivinityModData> mods, CancellationToken t)
+	{
+		if (!CanFetchData)
+		{
+			return false;
+		}
+
+		var targetMods = mods
+			.Where(mod => mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START
+				&& !mod.NexusModsData.ChangelogsLoaded)
+			.ToList();
+		if (targetMods.Count == 0)
+		{
+			return false;
+		}
+
+		_isActive = true;
+		var totalLoaded = 0;
+		try
+		{
+			if (!CanDoTask(targetMods.Count))
+			{
+				var apiAmounts = _client.RateLimitsManagement.APILimits;
+				DivinityApp.Log($"Changelog task would exceed hourly or daily Nexus Mods API limits. ExpectedCalls({targetMods.Count}) HourlyRemaining({apiAmounts.HourlyRemaining}/{apiAmounts.HourlyLimit}) DailyRemaining({apiAmounts.DailyRemaining}/{apiAmounts.DailyLimit})");
+				return false;
+			}
+
+			DivinityApp.Log($"Using Nexus Mods API to load changelogs for {targetMods.Count} mod(s)");
+			var dataLoader = new InfosInquirer(_client);
+			foreach (var mod in targetMods)
+			{
+				if (t.IsCancellationRequested)
+				{
+					break;
+				}
+
+				try
+				{
+					var result = await dataLoader.Mods.GetModChangelogs(DivinityApp.NEXUSMODS_GAME_DOMAIN, mod.NexusModsData.ModId, t);
+					mod.NexusModsData.SetChangelogs(result ?? new Dictionary<string, IEnumerable<string>>());
+					totalLoaded++;
+				}
+				catch (Exception ex)
+				{
+					DivinityApp.Log($"Error fetching Nexus Mods changelog for mod ID {mod.NexusModsData.ModId}:\n{ex}");
+				}
+			}
+		}
+		finally
+		{
+			OnTaskDone();
+		}
+
+		return totalLoaded > 0;
 	}
 }

--- a/src/GUI/App.xaml.cs
+++ b/src/GUI/App.xaml.cs
@@ -20,8 +20,6 @@ namespace DivinityModManager;
 /// </summary>
 public partial class App : Application
 {
-	public SplashScreen Splash { get; set; }
-
 	public App()
 	{
 		Services.RegisterSingleton<IFileWatcherService>(new FileWatcherService());
@@ -67,13 +65,7 @@ public partial class App : Application
 
 		EventManager.RegisterClassHandler(typeof(Window), Window.PreviewMouseDownEvent, new MouseButtonEventHandler(OnPreviewMouseDown));
 
-		var splashFade = new System.Threading.Thread(() =>
-		{
-			Splash.Close(TimeSpan.FromSeconds(1));
-		});
-
 		var mainWindow = new MainWindow();
-		splashFade.Start();
 		mainWindow.Show();
 	}
 

--- a/src/GUI/Controls/AlertBar.xaml
+++ b/src/GUI/Controls/AlertBar.xaml
@@ -37,40 +37,51 @@
 	</UserControl.Triggers>
 	<Grid Name="grdWrapper" Visibility="Collapsed">
 		<StackPanel Name="spStandard" Visibility="Collapsed">
-			<Grid>
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="26" />
-					<ColumnDefinition Width="*" />
-					<ColumnDefinition Width="20" />
-				</Grid.ColumnDefinitions>
-				<Image Grid.Column="0"
-				    Width="16"
-				    Height="16"
-				    Margin="10,4,0,4"
-				    VerticalAlignment="Center" />
-				<TextBlock Grid.Column="1"
-				    Margin="5,0,5,0"
-				    VerticalAlignment="Center"
-				    FontSize="11"
-				    FontWeight="Bold" />
-				<Image Grid.Column="2"
-				    Width="10"
-				    Height="10"
-				    Margin="0,4,10,4"
-				    VerticalAlignment="Center"
-				    MouseUp="Image_MouseUp">
-					<Image.Style>
-						<Style>
-							<Setter Property="Image.Source" Value="../Resources/Icons/AlertBar_Close.png" />
-							<Style.Triggers>
-								<Trigger Property="Image.IsMouseOver" Value="True">
-									<Setter Property="Image.Source" Value="../Resources/Icons/AlertBar_Close_Hover.png" />
-								</Trigger>
-							</Style.Triggers>
-						</Style>
-					</Image.Style>
-				</Image>
-			</Grid>
+			<Border x:Name="bdrStandard"
+				Margin="4,2"
+				Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+				BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
+				BorderThickness="3,1,1,1"
+				CornerRadius="6"
+				SnapsToDevicePixels="True">
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="30" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="26" />
+					</Grid.ColumnDefinitions>
+					<Image Grid.Column="0"
+					    Width="16"
+					    Height="16"
+					    Margin="9,4,0,4"
+					    VerticalAlignment="Center" />
+					<TextBlock Grid.Column="1"
+					    Margin="7,3"
+					    VerticalAlignment="Center"
+					    FontFamily="Segoe UI"
+					    FontSize="12"
+					    FontWeight="SemiBold"
+					    Foreground="{DynamicResource ReduxTextPrimaryBrush}"
+					    TextTrimming="CharacterEllipsis" />
+					<Image Grid.Column="2"
+					    Width="10"
+					    Height="10"
+					    Margin="4,4,10,4"
+					    VerticalAlignment="Center"
+					    MouseUp="Image_MouseUp">
+						<Image.Style>
+							<Style>
+								<Setter Property="Image.Source" Value="../Resources/Icons/AlertBar_Close.png" />
+								<Style.Triggers>
+									<Trigger Property="Image.IsMouseOver" Value="True">
+										<Setter Property="Image.Source" Value="../Resources/Icons/AlertBar_Close_Hover.png" />
+									</Trigger>
+								</Style.Triggers>
+							</Style>
+						</Image.Style>
+					</Image>
+				</Grid>
+			</Border>
 		</StackPanel>
 		<StackPanel Name="spOutline" Visibility="Collapsed">
 			<Border Name="bdr" BorderThickness="2" CornerRadius="5">
@@ -89,8 +100,10 @@
 						<TextBlock Grid.Column="1"
 						    Margin="5,0,5,0"
 						    VerticalAlignment="Center"
-						    FontSize="11"
-						    FontWeight="Bold" />
+						    FontFamily="Segoe UI"
+						    FontSize="12"
+						    FontWeight="SemiBold"
+						    Foreground="{DynamicResource ReduxTextPrimaryBrush}" />
 						<Image Grid.Column="2"
 						    Width="10"
 						    Height="10"

--- a/src/GUI/Controls/AlertBar.xaml.cs
+++ b/src/GUI/Controls/AlertBar.xaml.cs
@@ -59,7 +59,7 @@ public partial class AlertBar : UserControl
 				spOutline.Visibility = Visibility.Collapsed;
 
 				grdParent = FindVisualChildren<Grid>(spStandard).FirstOrDefault();
-				grdParent.Background = bg;
+				bdrStandard.BorderBrush = bg;
 				break;
 			case ThemeType.Outline:
 			default:
@@ -159,7 +159,7 @@ public partial class AlertBar : UserControl
 	{
 		_syncContext.Post(o =>
 		{
-			string color = "#D9534F";
+			string color = "#D95D6A";
 			TransformStage(message, timeoutInSeconds, color, (BitmapImage)this.Resources["AlertBar_Danger"]);
 		}, null);
 	}
@@ -173,7 +173,7 @@ public partial class AlertBar : UserControl
 	{
 		_syncContext.Post(o =>
 		{
-			string color = "#F0AD4E";
+			string color = "#D7A24B";
 			TransformStage(message, timeoutInSeconds, color, (BitmapImage)this.Resources["AlertBar_Warning"]);
 		}, null);
 	}
@@ -187,7 +187,7 @@ public partial class AlertBar : UserControl
 	{
 		_syncContext.Post(o =>
 		{
-			string color = "#5CB85C";
+			string color = "#3FA37A";
 			TransformStage(message, timeoutInSeconds, color, (BitmapImage)this.Resources["AlertBar_Success"]);
 		}, null);
 	}
@@ -202,7 +202,7 @@ public partial class AlertBar : UserControl
 	{
 		_syncContext.Post(o =>
 		{
-			string color = "#5BC0DE";
+			string color = "#8A6AF1";
 			TransformStage(message, timeoutInSeconds, color, (BitmapImage)this.Resources["AlertBar_Information"]);
 		}, null);
 	}

--- a/src/GUI/Converters/ModDetailsMediaWidthConverter.cs
+++ b/src/GUI/Converters/ModDetailsMediaWidthConverter.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace DivinityModManager.Converters;
+
+public class ModDetailsMediaWidthConverter : IValueConverter
+{
+	private const double MinimumWidth = 250;
+	private const double MaximumWidth = 620;
+	private const double FooterHeight = 29;
+	private const double WidescreenAspectRatio = 16d / 9d;
+
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		if (value is not double cardHeight || Double.IsNaN(cardHeight) || Double.IsInfinity(cardHeight))
+		{
+			return MinimumWidth;
+		}
+
+		var previewHeight = Math.Max(0, cardHeight - FooterHeight);
+		return Math.Clamp(previewHeight * WidescreenAspectRatio, MinimumWidth, MaximumWidth);
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		throw new NotSupportedException();
+	}
+}

--- a/src/GUI/Converters/NexusDescriptionToPlainTextConverter.cs
+++ b/src/GUI/Converters/NexusDescriptionToPlainTextConverter.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Windows.Data;
+
+namespace DivinityModManager.Converters;
+
+public class NexusDescriptionToPlainTextConverter : IValueConverter
+{
+	private const string EmptyDescriptionText = "No Nexus Mods description is available for this mod.";
+
+	private static readonly Regex ImagePattern = new(@"\[img(?:=[^\]]*)?\].*?\[/img\]", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+	private static readonly Regex ListItemStartPattern = new(@"\[li(?:=[^\]]*)?\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	private static readonly Regex ListItemEndPattern = new(@"\[/li\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	private static readonly Regex BlockTagPattern = new(@"\[/?(?:br|p|quote|center|left|right|list|ul|ol|spoiler|h[1-6]|heading)(?:=[^\]]*)?\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	private static readonly Regex RemainingBbCodePattern = new(@"\[[^\]]+\]", RegexOptions.Compiled);
+	private static readonly Regex HtmlBreakPattern = new(@"<(?:br\s*/?|/?p|/?div|/?li|/?ul|/?ol|/?blockquote)[^>]*>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	private static readonly Regex RemainingHtmlPattern = new(@"<[^>]+>", RegexOptions.Compiled);
+	private static readonly Regex HorizontalWhitespacePattern = new(@"[ \t]+", RegexOptions.Compiled);
+	private static readonly Regex LinePaddingPattern = new(@"[ \t]*\n[ \t]*", RegexOptions.Compiled);
+	private static readonly Regex ExcessBlankLinesPattern = new(@"\n{3,}", RegexOptions.Compiled);
+
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		var emptyText = parameter as string ?? EmptyDescriptionText;
+		if (value is not string description || String.IsNullOrWhiteSpace(description))
+		{
+			return emptyText;
+		}
+
+		var text = description.Replace("\r\n", "\n").Replace('\r', '\n');
+		text = ImagePattern.Replace(text, "\n[Image available on the Nexus Mods page]\n");
+		text = ListItemStartPattern.Replace(text, "\n• ");
+		text = ListItemEndPattern.Replace(text, "\n");
+		text = BlockTagPattern.Replace(text, "\n");
+		text = RemainingBbCodePattern.Replace(text, String.Empty);
+		text = HtmlBreakPattern.Replace(text, "\n");
+		text = RemainingHtmlPattern.Replace(text, String.Empty);
+		text = WebUtility.HtmlDecode(text).Replace('\u00A0', ' ');
+		text = HorizontalWhitespacePattern.Replace(text, " ");
+		text = LinePaddingPattern.Replace(text, "\n");
+		text = ExcessBlankLinesPattern.Replace(text, "\n\n");
+
+		return String.IsNullOrWhiteSpace(text) ? emptyText : text.Trim();
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		throw new NotSupportedException();
+	}
+}

--- a/src/GUI/Program.cs
+++ b/src/GUI/Program.cs
@@ -1,13 +1,11 @@
 ﻿using DivinityModManager.Util.ScreenReader;
 
 using System.Reflection;
-using System.Windows;
 
 namespace DivinityModManager;
 
 internal class Program
 {
-	private static SplashScreen _splash;
 	private static string _libDirectory;
 
 	private static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
@@ -40,13 +38,7 @@ internal class Program
 		_libDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "_Lib");
 		AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
 
-		_splash = new SplashScreen("Resources/BG3MMSplashScreen.png");
-		_splash.Show(false, false);
-
-		var app = new App
-		{
-			Splash = _splash
-		};
+		var app = new App();
 		app.Exit += OnAppExit;
 		app.InitializeComponent();
 		app.Run();

--- a/src/GUI/Resources/AppFeatures.json
+++ b/src/GUI/Resources/AppFeatures.json
@@ -1,5 +1,5 @@
 {
   "ScriptExtender": true,
-  "NexusMods": false,
+  "NexusMods": true,
   "Workshop": false
 }

--- a/src/GUI/Themes/Dark.xaml
+++ b/src/GUI/Themes/Dark.xaml
@@ -6,6 +6,43 @@
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="pack://application:,,,/AdonisUI;component/ColorSchemes/Dark.xaml" />
 	</ResourceDictionary.MergedDictionaries>
+	<!--  BG3 Mod Manager Redux semantic palette  -->
+	<Color x:Key="ReduxWindowColor">#141218</Color>
+	<Color x:Key="ReduxListInteriorColor">#17151C</Color>
+	<Color x:Key="ReduxSurfaceColor">#1E1A26</Color>
+	<Color x:Key="ReduxSurfaceElevatedColor">#211D28</Color>
+	<Color x:Key="ReduxSurfaceMutedColor">#24202C</Color>
+	<Color x:Key="ReduxBorderColor">#312B3A</Color>
+	<Color x:Key="ReduxBorderStrongColor">#3A3346</Color>
+	<Color x:Key="ReduxAccentColor">#8A6AF1</Color>
+	<Color x:Key="ReduxAccentHoverColor">#A58BFF</Color>
+	<Color x:Key="ReduxAccentSoftColor">#342B49</Color>
+	<Color x:Key="ReduxSelectionColor">#3A2E50</Color>
+	<Color x:Key="ReduxCyanColor">#3FA37A</Color>
+	<Color x:Key="ReduxSuccessColor">#3FA37A</Color>
+	<Color x:Key="ReduxWarningColor">#D7A24B</Color>
+	<Color x:Key="ReduxTextPrimaryColor">#ECE8F2</Color>
+	<Color x:Key="ReduxTextSecondaryColor">#B8B1C7</Color>
+	<Color x:Key="ReduxTextMutedColor">#8F879E</Color>
+	<Color x:Key="ReduxAccentForegroundColor">#F8F5FF</Color>
+	<SolidColorBrush x:Key="ReduxWindowBrush" Color="{DynamicResource ReduxWindowColor}" />
+	<SolidColorBrush x:Key="ReduxListInteriorBrush" Color="{DynamicResource ReduxListInteriorColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceBrush" Color="{DynamicResource ReduxSurfaceColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceElevatedBrush" Color="{DynamicResource ReduxSurfaceElevatedColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceMutedBrush" Color="{DynamicResource ReduxSurfaceMutedColor}" />
+	<SolidColorBrush x:Key="ReduxBorderBrush" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="ReduxBorderStrongBrush" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="ReduxAccentBrush" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="ReduxAccentHoverBrush" Color="{DynamicResource ReduxAccentHoverColor}" />
+	<SolidColorBrush x:Key="ReduxAccentSoftBrush" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="ReduxSelectionBrush" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="ReduxCyanBrush" Color="{DynamicResource ReduxCyanColor}" />
+	<SolidColorBrush x:Key="ReduxSuccessBrush" Color="{DynamicResource ReduxSuccessColor}" />
+	<SolidColorBrush x:Key="ReduxWarningBrush" Color="{DynamicResource ReduxWarningColor}" />
+	<SolidColorBrush x:Key="ReduxTextPrimaryBrush" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="ReduxTextSecondaryBrush" Color="{DynamicResource ReduxTextSecondaryColor}" />
+	<SolidColorBrush x:Key="ReduxTextMutedBrush" Color="{DynamicResource ReduxTextMutedColor}" />
+	<SolidColorBrush x:Key="ReduxAccentForegroundBrush" Color="{DynamicResource ReduxAccentForegroundColor}" />
 	<!--  colors  -->
 	<Color x:Key="{x:Static local:DivinityColors.TagBackgroundColor}">#495588</Color>
 	<Color x:Key="{x:Static local:DivinityColors.CustomTagBackgroundColor}">#497688</Color>

--- a/src/GUI/Themes/Light.xaml
+++ b/src/GUI/Themes/Light.xaml
@@ -6,6 +6,43 @@
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="pack://application:,,,/AdonisUI;component/ColorSchemes/Light.xaml" />
 	</ResourceDictionary.MergedDictionaries>
+	<!--  BG3 Mod Manager Redux semantic palette  -->
+	<Color x:Key="ReduxWindowColor">#F3F4FA</Color>
+	<Color x:Key="ReduxListInteriorColor">#F8F8FD</Color>
+	<Color x:Key="ReduxSurfaceColor">#FFFFFF</Color>
+	<Color x:Key="ReduxSurfaceElevatedColor">#F8F8FD</Color>
+	<Color x:Key="ReduxSurfaceMutedColor">#ECEEF7</Color>
+	<Color x:Key="ReduxBorderColor">#D8DDEB</Color>
+	<Color x:Key="ReduxBorderStrongColor">#BBC3D8</Color>
+	<Color x:Key="ReduxAccentColor">#6755E8</Color>
+	<Color x:Key="ReduxAccentHoverColor">#5845D8</Color>
+	<Color x:Key="ReduxAccentSoftColor">#EAE6FF</Color>
+	<Color x:Key="ReduxSelectionColor">#DDD6FF</Color>
+	<Color x:Key="ReduxCyanColor">#0BA99D</Color>
+	<Color x:Key="ReduxSuccessColor">#2F8F67</Color>
+	<Color x:Key="ReduxWarningColor">#B7791F</Color>
+	<Color x:Key="ReduxTextPrimaryColor">#11162A</Color>
+	<Color x:Key="ReduxTextSecondaryColor">#4C5570</Color>
+	<Color x:Key="ReduxTextMutedColor">#7B849D</Color>
+	<Color x:Key="ReduxAccentForegroundColor">#FFFFFF</Color>
+	<SolidColorBrush x:Key="ReduxWindowBrush" Color="{DynamicResource ReduxWindowColor}" />
+	<SolidColorBrush x:Key="ReduxListInteriorBrush" Color="{DynamicResource ReduxListInteriorColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceBrush" Color="{DynamicResource ReduxSurfaceColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceElevatedBrush" Color="{DynamicResource ReduxSurfaceElevatedColor}" />
+	<SolidColorBrush x:Key="ReduxSurfaceMutedBrush" Color="{DynamicResource ReduxSurfaceMutedColor}" />
+	<SolidColorBrush x:Key="ReduxBorderBrush" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="ReduxBorderStrongBrush" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="ReduxAccentBrush" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="ReduxAccentHoverBrush" Color="{DynamicResource ReduxAccentHoverColor}" />
+	<SolidColorBrush x:Key="ReduxAccentSoftBrush" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="ReduxSelectionBrush" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="ReduxCyanBrush" Color="{DynamicResource ReduxCyanColor}" />
+	<SolidColorBrush x:Key="ReduxSuccessBrush" Color="{DynamicResource ReduxSuccessColor}" />
+	<SolidColorBrush x:Key="ReduxWarningBrush" Color="{DynamicResource ReduxWarningColor}" />
+	<SolidColorBrush x:Key="ReduxTextPrimaryBrush" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="ReduxTextSecondaryBrush" Color="{DynamicResource ReduxTextSecondaryColor}" />
+	<SolidColorBrush x:Key="ReduxTextMutedBrush" Color="{DynamicResource ReduxTextMutedColor}" />
+	<SolidColorBrush x:Key="ReduxAccentForegroundBrush" Color="{DynamicResource ReduxAccentForegroundColor}" />
 	<!--  colors  -->
 	<Color x:Key="{x:Static local:DivinityColors.TagBackgroundColor}">#495588</Color>
 	<Color x:Key="{x:Static local:DivinityColors.CustomTagBackgroundColor}">#497688</Color>

--- a/src/GUI/Themes/MainResourceDictionary.xaml
+++ b/src/GUI/Themes/MainResourceDictionary.xaml
@@ -28,6 +28,51 @@
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="DefaultStyles/ComboBox.xaml" />
 	</ResourceDictionary.MergedDictionaries>
+	<!--  Bridge legacy AdonisUI controls into the Redux semantic palette.  -->
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.ForegroundBrush}" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.DisabledForegroundBrush}" Color="{DynamicResource ReduxTextMutedColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.AccentBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.AccentForegroundBrush}" Color="{DynamicResource ReduxAccentForegroundColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.AccentInteractionBorderBrush}" Color="{DynamicResource ReduxAccentHoverColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.AlertBrush}" Color="{DynamicResource ReduxWarningColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.SuccessBrush}" Color="{DynamicResource ReduxSuccessColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer0BackgroundBrush}" Color="{DynamicResource ReduxWindowColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1BackgroundBrush}" Color="{DynamicResource ReduxSurfaceElevatedColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1BorderBrush}" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1HighlightBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1HighlightBorderBrush}" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1IntenseHighlightBrush}" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1IntenseHighlightBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1InteractionBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1InteractionBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer1InteractionForegroundBrush}" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2BackgroundBrush}" Color="{DynamicResource ReduxSurfaceColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2BorderBrush}" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2HighlightBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2HighlightBorderBrush}" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2IntenseHighlightBrush}" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2IntenseHighlightBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2InteractionBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2InteractionBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer2InteractionForegroundBrush}" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3BackgroundBrush}" Color="{DynamicResource ReduxSurfaceMutedColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3BorderBrush}" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3HighlightBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3HighlightBorderBrush}" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3IntenseHighlightBrush}" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3IntenseHighlightBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3InteractionBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3InteractionBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer3InteractionForegroundBrush}" Color="{DynamicResource ReduxTextPrimaryColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4BackgroundBrush}" Color="{DynamicResource ReduxListInteriorColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4BorderBrush}" Color="{DynamicResource ReduxBorderColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4HighlightBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4HighlightBorderBrush}" Color="{DynamicResource ReduxBorderStrongColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4IntenseHighlightBrush}" Color="{DynamicResource ReduxSelectionColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4IntenseHighlightBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4InteractionBrush}" Color="{DynamicResource ReduxAccentSoftColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4InteractionBorderBrush}" Color="{DynamicResource ReduxAccentColor}" />
+	<SolidColorBrush x:Key="{x:Static adonisUI:Brushes.Layer4InteractionForegroundBrush}" Color="{DynamicResource ReduxTextPrimaryColor}" />
 	<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 	<conv:BoolToVisibilityConverterReversed x:Key="BoolToVisibilityConverterReversed" />
 	<conv:ModExistsConverter x:Key="ModExistsConverter" />
@@ -124,7 +169,7 @@
 	<Style BasedOn="{StaticResource {x:Type ToolTip}}" TargetType="{x:Type ToolTip}">
 		<Setter Property="OverridesDefaultStyle" Value="true" />
 		<Setter Property="HasDropShadow" Value="True" />
-		<Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUI:Brushes.ForegroundBrush}}" />
+		<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ToolTip">
@@ -132,9 +177,10 @@
 					    Width="{TemplateBinding Width}"
 					    Height="{TemplateBinding Height}"
 					    Padding="4"
-					    Background="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}"
-					    BorderBrush="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBorderBrush}}"
-					    BorderThickness="2">
+					    Background="{DynamicResource ReduxSurfaceBrush}"
+					    BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
+					    BorderThickness="1"
+					    CornerRadius="8">
 						<ContentPresenter Margin="4" HorizontalAlignment="Left" VerticalAlignment="Top" />
 					</Border>
 					<ControlTemplate.Triggers>
@@ -209,6 +255,8 @@
 	</Style>
 
 	<Style x:Key="ModuleShortDescListBox" BasedOn="{StaticResource {x:Type ListBox}}" TargetType="ListBox">
+		<Setter Property="Background" Value="{DynamicResource ReduxListInteriorBrush}" />
+		<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
 		<Setter Property="ItemContainerStyle">
 			<Setter.Value>
 				<Style TargetType="ListBoxItem">
@@ -219,7 +267,7 @@
 		<Setter Property="Margin" Value="2" />
 		<Setter Property="Padding" Value="0" />
 		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBorderBrush}}" />
+		<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
 	</Style>
 
 	<DataTemplate x:Key="DependencyModTemplate" DataType="{x:Type data:ModuleShortDesc}">
@@ -254,6 +302,12 @@
 
 	<Style x:Key="DivinityModDataListItem" BasedOn="{StaticResource {x:Type ListViewItem}}" TargetType="{x:Type ListViewItem}">
 		<Setter Property="behavior:ScreenReaderHelperBehavior.Automatic" Value="True" />
+		<Setter Property="MinHeight" Value="32" />
+		<Setter Property="Padding" Value="8,3" />
+		<Setter Property="Margin" Value="0,0,0,1" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="BorderBrush" Value="Transparent" />
+		<Setter Property="BorderThickness" Value="3,0,0,0" />
 		<!--<Style.Resources>
 			<LinearGradientBrush x:Key="ListItemHoverFill_Selected" StartPoint="0,0" EndPoint="0,1">
 				<GradientStop Offset="0" Color="#FFD1FFD1" />
@@ -373,7 +427,7 @@
 					<Setter Property="Control.Template">
 						<Setter.Value>
 							<ControlTemplate>
-								<Rectangle SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static adonisUI:Brushes.AccentIntenseHighlightBorderBrush}}" StrokeThickness="2" />
+								<Rectangle SnapsToDevicePixels="true" Stroke="{DynamicResource ReduxAccentHoverBrush}" StrokeThickness="2" />
 							</ControlTemplate>
 						</Setter.Value>
 					</Setter>
@@ -381,6 +435,13 @@
 			</Setter.Value>
 		</Setter>
 		<Style.Triggers>
+			<Trigger Property="IsMouseOver" Value="True">
+				<Setter Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+			</Trigger>
+			<Trigger Property="IsSelected" Value="True">
+				<Setter Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+			</Trigger>
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
 					<Condition Binding="{Binding HasColorOverride}" Value="True" />
@@ -433,7 +494,7 @@
 		<Setter Property="Tag" Value="{Binding UpdatedMod}" />
 	</Style>
 	<Style BasedOn="{StaticResource {x:Type ListView}}" TargetType="controls:ModListView">
-		<Setter Property="Background" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}" />
+		<Setter Property="Background" Value="{DynamicResource ReduxListInteriorBrush}" />
 	</Style>
 	<Style x:Key="ModOrderListView" BasedOn="{StaticResource {x:Type ListView}}" TargetType="ListView">
 		<Setter Property="KeyboardNavigation.AcceptsReturn" Value="False" />
@@ -448,6 +509,20 @@
 						<ScrollViewer Name="ListScrollViewer" Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
 							<ItemsPresenter x:Name="ListItemsPresenter" />
 						</ScrollViewer>
+						<Border Name="EmptyStatePanel"
+							Margin="24"
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							IsHitTestVisible="False"
+							Visibility="Collapsed">
+							<StackPanel HorizontalAlignment="Center">
+								<TextBlock HorizontalAlignment="Center" FontSize="14" FontWeight="SemiBold" Text="No mods here yet" />
+								<TextBlock Margin="0,6,0,0"
+									HorizontalAlignment="Center"
+									Foreground="{DynamicResource ReduxTextMutedBrush}"
+									Text="Use Install Mod or move a mod into this list." />
+							</StackPanel>
+						</Border>
 						<Rectangle Name="DisabledRect"
 						    HorizontalAlignment="Stretch"
 						    VerticalAlignment="Stretch"
@@ -457,6 +532,9 @@
 						    Visibility="Collapsed" />
 					</Grid>
 					<ControlTemplate.Triggers>
+						<Trigger Property="HasItems" Value="False">
+							<Setter TargetName="EmptyStatePanel" Property="Visibility" Value="Visible" />
+						</Trigger>
 						<Trigger Property="IsGrouping" Value="True">
 							<Setter TargetName="ListScrollViewer" Property="CanContentScroll" Value="False" />
 						</Trigger>
@@ -540,10 +618,11 @@
 				<Setter Property="Template">
 					<Setter.Value>
 						<ControlTemplate TargetType="controls:AutomationTooltip">
-							<Border Padding="8"
-							    Background="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}"
-							    BorderBrush="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBorderBrush}}"
-							    BorderThickness="2">
+							<Border Padding="10"
+							    Background="{DynamicResource ReduxSurfaceBrush}"
+							    BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
+							    BorderThickness="1"
+							    CornerRadius="8">
 								<ContentPresenter />
 							</Border>
 						</ControlTemplate>
@@ -559,7 +638,7 @@
 				<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="TextBlock">
 					<Setter Property="TextWrapping" Value="Wrap" />
 					<Setter Property="Margin" Value="2" />
-					<Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUI:Brushes.ForegroundBrush}}" />
+					<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
 					<!--<Setter Property="FontFamily" Value="Arial" />-->
 				</Style>
 				<Style BasedOn="{StaticResource {x:Type ListBox}}" TargetType="ListBox" />
@@ -572,7 +651,7 @@
 				</Grid.ColumnDefinitions>
 				<TextBlock FontSize="16"
 				    FontWeight="Bold"
-				    Foreground="{DynamicResource {x:Static adonisUI:Brushes.AlertBrush}}"
+				    Foreground="{DynamicResource ReduxAccentHoverBrush}"
 				    Text="{Binding DisplayName}">
 					<TextBlock.Effect>
 						<DropShadowEffect BlurRadius="4"
@@ -595,8 +674,8 @@
 				</StackPanel>
 			</Grid>
 
-			<Separator Background="{DynamicResource {x:Static adonisUI:Brushes.Layer1HighlightBorderBrush}}" />
-			<TextBlock TextWrapping="Wrap" Visibility="{Binding AuthorVisibility}"><Run Text="Created by " /><Run FontWeight="Bold" Foreground="#3da2fa" Text="{Binding Author}" />
+			<Separator Background="{DynamicResource ReduxBorderBrush}" />
+			<TextBlock TextWrapping="Wrap" Visibility="{Binding AuthorVisibility}"><Run Text="Created by " /><Run FontWeight="Bold" Foreground="{DynamicResource ReduxAccentHoverBrush}" Text="{Binding Author}" />
 				<TextBlock.Effect>
 					<DropShadowEffect BlurRadius="4"
 					    Direction="330"
@@ -610,9 +689,9 @@
 			    TextWrapping="Wrap"
 			    Visibility="{Binding DescriptionVisibility}" />
 			<StackPanel Orientation="Vertical" Visibility="{Binding NexusModsInformationVisibility}">
-				<Separator Background="{DynamicResource {x:Static adonisUI:Brushes.Layer1HighlightBorderBrush}}" />
+				<Separator Background="{DynamicResource ReduxBorderBrush}" />
 				<TextBlock Text="{Binding NexusModsTooltipInfo}" />
-				<Separator Background="{DynamicResource {x:Static adonisUI:Brushes.Layer1HighlightBorderBrush}}" />
+				<Separator Background="{DynamicResource ReduxBorderBrush}" />
 			</StackPanel>
 			<StackPanel Margin="2" Orientation="Vertical" Visibility="{Binding DependencyVisibility, FallbackValue=Collapsed}">
 				<TextBlock FontWeight="Bold" Text="Dependencies:" />
@@ -645,9 +724,9 @@
 				</ItemsControl>
 			</StackPanel>
 			<StackPanel Orientation="Vertical">
-				<Separator Background="{DynamicResource {x:Static adonisUI:Brushes.Layer1HighlightBorderBrush}}" />
+				<Separator Background="{DynamicResource ReduxBorderBrush}" />
 				<TextBlock Text="{Binding FileName}" Visibility="{Binding HasFilePathVisibility}" />
-				<TextBlock Foreground="Goldenrod" Text="{Binding ScriptExtenderSupportToolTipText}" Visibility="{Binding ExtenderStatusVisibility}" />
+				<TextBlock Foreground="{DynamicResource ReduxWarningBrush}" Text="{Binding ScriptExtenderSupportToolTipText}" Visibility="{Binding ExtenderStatusVisibility}" />
 				<TextBlock Margin="2" Text="{Binding LastModifiedDateText}" />
 			</StackPanel>
 			<StackPanel Margin="2" Orientation="Vertical" Visibility="{Binding IsForceLoaded, Converter={StaticResource BoolToVisibilityConverter}, FallbackValue=Collapsed}">
@@ -826,8 +905,15 @@
 		</controls:ModEntryGrid>
 	</DataTemplate>
 	<Style x:Key="GridViewLeftContainerStyle" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}" TargetType="{x:Type GridViewColumnHeader}">
+		<Setter Property="Height" Value="30" />
+		<Setter Property="Padding" Value="8,0" />
+		<Setter Property="FontWeight" Value="SemiBold" />
+		<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+		<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+		<Setter Property="Foreground" Value="{DynamicResource ReduxTextSecondaryBrush}" />
 		<Setter Property="HorizontalContentAlignment" Value="Left" />
-		<Setter Property="Margin" Value="4,0,0,0" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="Margin" Value="0" />
 	</Style>
 	<Style x:Key="GridViewCenteredContainerStyle" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}" TargetType="{x:Type GridViewColumnHeader}">
 		<Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -971,7 +1057,7 @@
 		<Setter Property="OverlayStyle">
 			<Setter.Value>
 				<Style TargetType="Rectangle">
-					<Setter Property="Fill" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}" />
+					<Setter Property="Fill" Value="{DynamicResource ReduxWindowBrush}" />
 					<!--<Setter Property="Opacity" Value="0.75" />-->
 				</Style>
 			</Setter.Value>
@@ -980,7 +1066,7 @@
 			<Setter.Value>
 				<Style BasedOn="{StaticResource {x:Type ProgressBar}}" TargetType="ProgressBar">
 					<Setter Property="Visibility" Value="Collapsed" />
-					<Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBrush}}" />
+					<Setter Property="Foreground" Value="{DynamicResource ReduxAccentBrush}" />
 				</Style>
 			</Setter.Value>
 		</Setter>
@@ -1013,11 +1099,11 @@
 									    Grid.Column="1"
 									    HorizontalAlignment="Stretch"
 									    VerticalAlignment="Stretch">
-										<Border Background="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}"
-										    BorderBrush="{DynamicResource {x:Static adonisUI:Brushes.Layer4InteractionBorderBrush}}"
+										<Border Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+										    BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
 										    BorderThickness="1"
-										    CornerRadius="2">
-											<Border Margin="1" Background="{DynamicResource {x:Static adonisUI:Brushes.Layer1BackgroundBrush}}" CornerRadius="1.5">
+										    CornerRadius="8">
+											<Border Margin="1" Background="{DynamicResource ReduxSurfaceBrush}" CornerRadius="7">
 												<Grid x:Name="_grid" MinWidth="150">
 													<Grid.RowDefinitions>
 														<RowDefinition />
@@ -1174,6 +1260,8 @@
 								    FontSize="{TemplateBinding FontSize}"
 								    FontStyle="{TemplateBinding FontStyle}"
 								    FontWeight="{TemplateBinding FontWeight}"
+								    Background="Transparent"
+								    BorderThickness="0"
 								    Foreground="{TemplateBinding Foreground}"
 								    IsReadOnly="True"
 								    Text="{TemplateBinding Text}"

--- a/src/GUI/Themes/MainResourceDictionary.xaml
+++ b/src/GUI/Themes/MainResourceDictionary.xaml
@@ -324,6 +324,43 @@
 							<Setter Property="Height" Value="16" />
 						</Style>
 					</ContextMenu.Resources>
+					<MenuItem Command="{Binding Path=MoveModToActiveCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+					    CommandParameter="{Binding}"
+					    Header="Move to Active Mods">
+						<MenuItem.Style>
+							<Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="MenuItem">
+								<Setter Property="Visibility" Value="Collapsed" />
+								<Style.Triggers>
+									<MultiDataTrigger>
+										<MultiDataTrigger.Conditions>
+											<Condition Binding="{Binding IsActive}" Value="False" />
+											<Condition Binding="{Binding CanAddToLoadOrder}" Value="True" />
+										</MultiDataTrigger.Conditions>
+										<Setter Property="Visibility" Value="Visible" />
+									</MultiDataTrigger>
+								</Style.Triggers>
+							</Style>
+						</MenuItem.Style>
+					</MenuItem>
+					<MenuItem Command="{Binding Path=MoveModToInactiveCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+					    CommandParameter="{Binding}"
+					    Header="Move to Inactive Mods">
+						<MenuItem.Style>
+							<Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="MenuItem">
+								<Setter Property="Visibility" Value="Collapsed" />
+								<Style.Triggers>
+									<MultiDataTrigger>
+										<MultiDataTrigger.Conditions>
+											<Condition Binding="{Binding IsActive}" Value="True" />
+											<Condition Binding="{Binding CanAddToLoadOrder}" Value="True" />
+										</MultiDataTrigger.Conditions>
+										<Setter Property="Visibility" Value="Visible" />
+									</MultiDataTrigger>
+								</Style.Triggers>
+							</Style>
+						</MenuItem.Style>
+					</MenuItem>
+					<Separator />
 					<MenuItem Command="{Binding Path=OpenInFileExplorerCommand, Source={x:Static dapp:DivinityApp.Commands}}" CommandParameter="{Binding FilePath}" Header="Open in File Explorer...">
 						<MenuItem.Icon>
 							<Image Source="{StaticResource OpenFolderImage}" />
@@ -331,7 +368,7 @@
 					</MenuItem>
 					<MenuItem Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
 					    CommandParameter="{Binding}"
-					    Header="Open NexusMods Page (Browser)..."
+					    Header="View Mod on Nexus Mods"
 					    IsEnabled="{Binding CanOpenNexusModsLink}"
 					    Visibility="{Binding OpenNexusModsLinkVisibility}">
 						<MenuItem.Icon>
@@ -791,9 +828,25 @@
 			<TextBlock x:Name="ModNameText"
 			    HorizontalAlignment="Stretch"
 			    Tag="{Binding}"
-			    Text="{Binding DisplayName}"
 			    ToolTip="{StaticResource ModToolTip}"
-			    ToolTipService.IsEnabled="{Binding HasToolTip}" />
+			    ToolTipService.IsEnabled="{Binding HasToolTip}">
+				<TextBlock.Style>
+					<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+						<Setter Property="Text" Value="{Binding DisplayName}" />
+						<Style.Triggers>
+							<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+								<Setter Property="Text" Value="{Binding NexusModsData.Name}" />
+							</DataTrigger>
+							<DataTrigger Binding="{Binding NexusModsData.Name}" Value="">
+								<Setter Property="Text" Value="{Binding DisplayName}" />
+							</DataTrigger>
+							<DataTrigger Binding="{Binding NexusModsData.Name}" Value="{x:Null}">
+								<Setter Property="Text" Value="{Binding DisplayName}" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</TextBlock.Style>
+			</TextBlock>
 			<Border Grid.Column="1" Padding="0,0,4,0" BorderThickness="0">
 				<StackPanel Orientation="Horizontal">
 					<Image Width="16"
@@ -904,6 +957,43 @@
 			</Border>
 		</controls:ModEntryGrid>
 	</DataTemplate>
+	<DataTemplate x:Key="ModAuthorTemplate" DataType="{x:Type data:DivinityModData}">
+		<TextBlock>
+			<TextBlock.Style>
+				<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+					<Setter Property="Text" Value="{Binding Author}" />
+					<Setter Property="ToolTip" Value="{Binding Author}" />
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+							<Setter Property="Text" Value="{Binding NexusModsData.Author}" />
+							<Setter Property="ToolTip" Value="{Binding NexusModsData.Author}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding NexusModsData.Author}" Value="">
+							<Setter Property="Text" Value="{Binding Author}" />
+							<Setter Property="ToolTip" Value="{Binding Author}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding NexusModsData.Author}" Value="{x:Null}">
+							<Setter Property="Text" Value="{Binding Author}" />
+							<Setter Property="ToolTip" Value="{Binding Author}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</TextBlock.Style>
+		</TextBlock>
+	</DataTemplate>
+	<DataTemplate x:Key="ModLastUpdatedTemplate" DataType="{x:Type data:DivinityModData}">
+		<TextBlock Text="{Binding DisplayLastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeColumnFormat}}"
+		    ToolTip="{Binding DisplayLastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeTooltipFormat}}" />
+	</DataTemplate>
+	<DataTemplate x:Key="ModLastModifiedTemplate" DataType="{x:Type data:DivinityModData}">
+		<TextBlock Text="{Binding LastModified, StringFormat={x:Static dapp:DivinityApp.DateTimeColumnFormat}}"
+		    ToolTip="{Binding LastModified, StringFormat={x:Static dapp:DivinityApp.DateTimeTooltipFormat}}" />
+	</DataTemplate>
+	<DataTemplate x:Key="ModSourceTemplate" DataType="{x:Type data:DivinityModData}">
+		<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}"
+		    Text="{Binding DisplaySource}"
+		    ToolTip="{Binding DisplaySource, StringFormat='Metadata source: {0}'}" />
+	</DataTemplate>
 	<Style x:Key="GridViewLeftContainerStyle" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}" TargetType="{x:Type GridViewColumnHeader}">
 		<Setter Property="Height" Value="30" />
 		<Setter Property="Padding" Value="8,0" />
@@ -951,20 +1041,10 @@
 					</DataTemplate>
 				</GridViewColumn.CellTemplate>
 			</GridViewColumn>
-			<GridViewColumn Width="100" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding Author}" ToolTip="{Binding Author}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
-			<GridViewColumn Width="Auto" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeColumnFormat}}" ToolTip="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeTooltipFormat}}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModAuthorTemplate}" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastUpdatedTemplate}" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastModifiedTemplate}" Header="Last Modified" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="90" CellTemplate="{StaticResource ModSourceTemplate}" Header="Source" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
 		</GridView.Columns>
 	</GridView>
 	<Style x:Key="GridViewHiddenLeftContainerStyle" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}" TargetType="{x:Type GridViewColumnHeader}">
@@ -1000,20 +1080,10 @@
 					</DataTemplate>
 				</GridViewColumn.CellTemplate>
 			</GridViewColumn>
-			<GridViewColumn Width="100" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding Author}" ToolTip="{Binding Author}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
-			<GridViewColumn Width="Auto" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeColumnFormat}}" ToolTip="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeTooltipFormat}}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModAuthorTemplate}" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastUpdatedTemplate}" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastModifiedTemplate}" Header="Last Modified" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="90" CellTemplate="{StaticResource ModSourceTemplate}" Header="Source" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
 		</GridView.Columns>
 	</GridView>
 	<GridView x:Key="InactiveModGridView"
@@ -1032,20 +1102,10 @@
 					</DataTemplate>
 				</GridViewColumn.CellTemplate>
 			</GridViewColumn>
-			<GridViewColumn Width="100" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding Author}" ToolTip="{Binding Author}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
-			<GridViewColumn Width="Auto" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}">
-				<GridViewColumn.CellTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeColumnFormat}}" ToolTip="{Binding LastUpdated, StringFormat={x:Static dapp:DivinityApp.DateTimeTooltipFormat}}" />
-					</DataTemplate>
-				</GridViewColumn.CellTemplate>
-			</GridViewColumn>
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModAuthorTemplate}" Header="Author" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastUpdatedTemplate}" Header="Last Updated" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="100" CellTemplate="{StaticResource ModLastModifiedTemplate}" Header="Last Modified" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
+			<GridViewColumn Width="90" CellTemplate="{StaticResource ModSourceTemplate}" Header="Source" HeaderTemplate="{StaticResource GridViewTextblockHeaderTemplate}" />
 		</GridView.Columns>
 	</GridView>
 

--- a/src/GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/GUI/ViewModels/MainWindowViewModel.cs
@@ -1055,6 +1055,10 @@ Directory the zip will be extracted to:
 
 		Settings.WhenAnyValue(x => x.NexusModsAPIKey).Subscribe((key) =>
 		{
+			UpdateHandler.Nexus.APIKey = key;
+			UpdateHandler.Nexus.AppName = AppTitle;
+			UpdateHandler.Nexus.AppVersion = Version.ToString();
+
 			if (String.IsNullOrEmpty(key))
 			{
 				NexusModsDataLoader.Dispose();
@@ -1150,6 +1154,8 @@ Directory the zip will be extracted to:
 				mod.NexusModsEnabled = DivinityApp.NexusModsEnabled;
 			}
 		}
+
+		UpdateHandler.Nexus.IsEnabled = DivinityApp.NexusModsEnabled;
 
 		if (Settings.LogEnabled)
 		{
@@ -1902,7 +1908,16 @@ Directory the zip will be extracted to:
 
 				if (UpdateHandler.Nexus.IsEnabled && result.Mods.Count > 0 && result.Mods.Any(x => x.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START))
 				{
-					await UpdateHandler.Nexus.Update(result.Mods, MainProgressToken.Token);
+					var cacheChanged = await UpdateHandler.Nexus.Update(result.Mods, MainProgressToken.Token);
+					cacheChanged |= await NexusModsDataLoader.LoadChangelogsAsync(result.Mods, MainProgressToken.Token);
+					if (cacheChanged)
+					{
+						foreach (var mod in result.Mods.Where(mod => mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START))
+						{
+							UpdateHandler.Nexus.CacheData.Mods[mod.UUID] = mod.NexusModsData;
+						}
+						await UpdateHandler.Nexus.SaveCacheAsync(false, Version.ToString(), MainProgressToken.Token);
+					}
 				}
 
 				await ctrl.Yield();
@@ -2280,6 +2295,82 @@ Directory the zip will be extracted to:
 		});
 	}
 
+	private void LoadNexusModsMetadataBackground()
+	{
+		if (!UpdateHandler.Nexus.IsEnabled || IsRefreshingModUpdates)
+		{
+			return;
+		}
+
+		var loadedUserMods = UserMods.ToList();
+		IsRefreshingModUpdates = true;
+
+		RxApp.TaskpoolScheduler.ScheduleAsync(async (scheduler, cancellationToken) =>
+		{
+			try
+			{
+				var cacheChanged = false;
+				var cachedData = await UpdateHandler.Nexus.LoadCacheAsync(Version.ToString(), cancellationToken);
+				if (cachedData != null)
+				{
+					UpdateHandler.Nexus.CacheData = cachedData;
+					await Observable.Start(() =>
+					{
+						foreach (var mod in loadedUserMods)
+						{
+							if (cachedData.Mods.TryGetValue(mod.UUID, out var nexusData))
+							{
+								mod.NexusModsData.Update(nexusData);
+							}
+						}
+					}, RxApp.MainThreadScheduler);
+				}
+
+				var missingMetadata = loadedUserMods
+					.Where(mod => mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START
+						&& (String.IsNullOrWhiteSpace(mod.NexusModsData.Name)
+							|| !mod.NexusModsData.DescriptionLoaded))
+					.ToList();
+
+				if (!String.IsNullOrWhiteSpace(Settings.NexusModsAPIKey)
+					&& missingMetadata.Count > 0
+					&& await UpdateHandler.Nexus.Update(missingMetadata, cancellationToken))
+				{
+					cacheChanged = true;
+				}
+
+				var missingChangelogs = loadedUserMods
+					.Where(mod => mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START
+						&& !mod.NexusModsData.ChangelogsLoaded)
+					.ToList();
+
+				if (!String.IsNullOrWhiteSpace(Settings.NexusModsAPIKey)
+					&& missingChangelogs.Count > 0
+					&& await NexusModsDataLoader.LoadChangelogsAsync(missingChangelogs, cancellationToken))
+				{
+					foreach (var mod in missingChangelogs)
+					{
+						UpdateHandler.Nexus.CacheData.Mods[mod.UUID] = mod.NexusModsData;
+					}
+					cacheChanged = true;
+				}
+
+				if (cacheChanged)
+				{
+					await UpdateHandler.Nexus.SaveCacheAsync(false, Version.ToString(), cancellationToken);
+				}
+			}
+			catch (Exception ex)
+			{
+				DivinityApp.Log($"Error loading Nexus Mods metadata:\n{ex}");
+			}
+			finally
+			{
+				RxApp.MainThreadScheduler.Schedule(() => IsRefreshingModUpdates = false);
+			}
+		});
+	}
+
 	private async Task CheckForEmptyOrderAsync(IScheduler sch, CancellationToken token)
 	{
 		if (SelectedProfile == null) return;
@@ -2531,6 +2622,7 @@ Directory the zip will be extracted to:
 			IsRefreshing = false;
 			IsLoadingOrder = false;
 			IsInitialized = true;
+			LoadNexusModsMetadataBackground();
 
 			if (AppSettings.FeatureEnabled("ScriptExtender"))
 			{
@@ -3082,7 +3174,16 @@ Directory the zip will be extracted to:
 				await ImportArchiveAsync(builtinMods, result, dialog.FileName, false, MainProgressToken.Token);
 				if (result.Mods.Count > 0 && result.Mods.Any(x => x.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START))
 				{
-					await UpdateHandler.Nexus.Update(result.Mods, MainProgressToken.Token);
+					var cacheChanged = await UpdateHandler.Nexus.Update(result.Mods, MainProgressToken.Token);
+					cacheChanged |= await NexusModsDataLoader.LoadChangelogsAsync(result.Mods, MainProgressToken.Token);
+					if (cacheChanged)
+					{
+						foreach (var mod in result.Mods.Where(mod => mod.NexusModsData.ModId >= DivinityApp.NEXUSMODS_MOD_ID_START))
+						{
+							UpdateHandler.Nexus.CacheData.Mods[mod.UUID] = mod.NexusModsData;
+						}
+						await UpdateHandler.Nexus.SaveCacheAsync(false, Version.ToString(), MainProgressToken.Token);
+					}
 				}
 				await ctrl.Yield(t);
 				RxApp.MainThreadScheduler.Schedule(_ =>
@@ -3318,6 +3419,10 @@ Directory the zip will be extracted to:
 									taskResult.TotalPaks++;
 									taskResult.Mods.Add(mod);
 									mod.NexusModsData.SetModVersion(info);
+									if (info.Success)
+									{
+										UpdateHandler.Nexus.CacheData.Mods[mod.UUID] = mod.NexusModsData;
+									}
 									await Observable.Start(() =>
 									{
 										AddImportedMod(mod, toActiveList);
@@ -3446,6 +3551,10 @@ Directory the zip will be extracted to:
 									{
 										taskResult.Mods.Add(mod);
 										mod.NexusModsData.SetModVersion(info);
+										if (info.Success)
+										{
+											UpdateHandler.Nexus.CacheData.Mods[mod.UUID] = mod.NexusModsData;
+										}
 										await Observable.Start(() =>
 										{
 											AddImportedMod(mod, toActiveList);

--- a/src/GUI/Views/DeleteFilesConfirmationView.xaml
+++ b/src/GUI/Views/DeleteFilesConfirmationView.xaml
@@ -19,10 +19,107 @@
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="../Themes/MainResourceDictionary.xaml" />
 			</ResourceDictionary.MergedDictionaries>
+			<Style x:Key="DeleteFilesCheckBoxStyle" TargetType="{x:Type CheckBox}">
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="VerticalContentAlignment" Value="Center" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type CheckBox}">
+							<StackPanel Orientation="Horizontal">
+								<Border x:Name="CheckSurface"
+								    Width="16"
+								    Height="16"
+								    VerticalAlignment="Center"
+								    Background="{DynamicResource ReduxSurfaceMutedBrush}"
+								    BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
+								    BorderThickness="1"
+								    CornerRadius="4">
+									<TextBlock x:Name="CheckMark"
+									    HorizontalAlignment="Center"
+									    VerticalAlignment="Center"
+									    FontSize="11"
+									    FontWeight="Bold"
+									    Foreground="{DynamicResource ReduxAccentForegroundBrush}"
+									    Text="&#x2713;"
+									    Visibility="Collapsed" />
+								</Border>
+								<ContentPresenter Margin="7,0,0,0" VerticalAlignment="Center" />
+							</StackPanel>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter TargetName="CheckSurface" Property="BorderBrush" Value="{DynamicResource ReduxAccentHoverBrush}" />
+								</Trigger>
+								<Trigger Property="IsChecked" Value="True">
+									<Setter TargetName="CheckSurface" Property="Background" Value="{DynamicResource ReduxAccentBrush}" />
+									<Setter TargetName="CheckSurface" Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+									<Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+								</Trigger>
+								<Trigger Property="IsEnabled" Value="False">
+									<Setter Property="Opacity" Value="0.45" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<ControlTemplate x:Key="DeleteFilesButtonTemplate" TargetType="{x:Type Button}">
+				<Border x:Name="ButtonSurface"
+				    Padding="{TemplateBinding Padding}"
+				    Background="{TemplateBinding Background}"
+				    BorderBrush="{TemplateBinding BorderBrush}"
+				    BorderThickness="{TemplateBinding BorderThickness}"
+				    CornerRadius="7">
+					<ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+				</Border>
+				<ControlTemplate.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter TargetName="ButtonSurface" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+						<Setter TargetName="ButtonSurface" Property="BorderBrush" Value="{DynamicResource ReduxAccentHoverBrush}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter TargetName="ButtonSurface" Property="Opacity" Value="0.78" />
+					</Trigger>
+					<Trigger Property="IsEnabled" Value="False">
+						<Setter TargetName="ButtonSurface" Property="Opacity" Value="0.45" />
+					</Trigger>
+				</ControlTemplate.Triggers>
+			</ControlTemplate>
+			<Style x:Key="DeleteFilesButtonStyle" TargetType="{x:Type Button}">
+				<Setter Property="MinWidth" Value="84" />
+				<Setter Property="Height" Value="32" />
+				<Setter Property="Padding" Value="14,4" />
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Template" Value="{StaticResource DeleteFilesButtonTemplate}" />
+			</Style>
+			<Style x:Key="DeleteFilesPrimaryButtonStyle" BasedOn="{StaticResource DeleteFilesButtonStyle}" TargetType="{x:Type Button}">
+				<Setter Property="Background" Value="{DynamicResource ReduxWarningBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxWarningBrush}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxWindowBrush}" />
+				<Setter Property="FontWeight" Value="SemiBold" />
+			</Style>
+			<Style BasedOn="{StaticResource {x:Type ListViewItem}}" TargetType="{x:Type ListViewItem}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Style.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+					</Trigger>
+					<Trigger Property="IsSelected" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+						<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+					</Trigger>
+				</Style.Triggers>
+			</Style>
 		</ResourceDictionary>
 	</UserControl.Resources>
 	<UserControl.Style>
-		<Style BasedOn="{StaticResource {x:Type UserControl}}" TargetType="UserControl" />
+		<Style BasedOn="{StaticResource {x:Type UserControl}}" TargetType="UserControl">
+			<Setter Property="Background" Value="{DynamicResource ReduxWindowBrush}" />
+			<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+		</Style>
 	</UserControl.Style>
 	<xc:BusyIndicator x:Name="ProgressIndicator" Style="{StaticResource BusyIndicatorProgressStyle}">
 		<xc:BusyIndicator.BusyContent>
@@ -61,7 +158,7 @@
 			<Grid.Resources>
 				<ControlTemplate x:Key="VerticalGridSplitter" TargetType="{x:Type GridSplitter}">
 					<Border Margin="0,-5" HorizontalAlignment="Stretch" Background="Transparent">
-						<TextBlock Height="1" HorizontalAlignment="Stretch" Background="{DynamicResource {x:Static adonisUI:Brushes.Layer3BackgroundBrush}}" />
+						<TextBlock Height="1" HorizontalAlignment="Stretch" Background="{DynamicResource ReduxBorderBrush}" />
 					</Border>
 				</ControlTemplate>
 			</Grid.Resources>
@@ -72,25 +169,30 @@
 			</Grid.RowDefinitions>
 			<StackPanel Orientation="Vertical">
 				<TextBlock x:Name="TitleTextBlock"
-				    Background="{DynamicResource {x:Static adonisUI:Brushes.Layer3BackgroundBrush}}"
+				    Padding="12,7"
+				    Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+				    Foreground="{DynamicResource ReduxTextPrimaryBrush}"
 				    FontSize="24"
 				    TextAlignment="Center" />
-				<Rectangle Height="2" Fill="LightGray" />
+				<Rectangle Height="1" Fill="{DynamicResource ReduxBorderBrush}" />
 			</StackPanel>
 			<ListView x:Name="FilesListView"
 			    Grid.Row="1"
-			    BorderThickness="0"
+			    Background="{DynamicResource ReduxListInteriorBrush}"
+			    BorderBrush="{DynamicResource ReduxBorderBrush}"
+			    BorderThickness="0,0,0,1"
+			    Foreground="{DynamicResource ReduxTextPrimaryBrush}"
 			    ScrollViewer.HorizontalScrollBarVisibility="Hidden">
 				<ListView.View>
 					<GridView x:Name="FileListGridView" AllowsColumnReorder="False" ColumnHeaderContainerStyle="{StaticResource GridViewLeftContainerStyle}">
 						<GridView.Columns>
 							<GridViewColumn Width="Auto" HeaderContainerStyle="{StaticResource GridViewCenteredContainerStyle}">
 								<GridViewColumn.Header>
-									<CheckBox Command="{Binding SelectAllCommand}" IsChecked="{Binding AllSelected, Mode=OneWay}" ToolTip="{Binding SelectAllTooltip}" />
+									<CheckBox Command="{Binding SelectAllCommand}" IsChecked="{Binding AllSelected, Mode=OneWay}" Style="{StaticResource DeleteFilesCheckBoxStyle}" ToolTip="{Binding SelectAllTooltip}" />
 								</GridViewColumn.Header>
 								<GridViewColumn.CellTemplate>
 									<DataTemplate>
-										<CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding IsSelected}" />
+										<CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding IsSelected}" Style="{StaticResource DeleteFilesCheckBoxStyle}" />
 									</DataTemplate>
 								</GridViewColumn.CellTemplate>
 							</GridViewColumn>
@@ -126,7 +228,7 @@
 				</ListView.View>
 			</ListView>
 			<Grid Grid.Row="2"
-			    Margin="4"
+			    Margin="4,10,4,12"
 			    HorizontalAlignment="Center"
 			    VerticalAlignment="Center">
 				<Grid>
@@ -139,22 +241,24 @@
 						    Margin="8"
 						    HorizontalAlignment="Center"
 						    Content="Permanent"
+						    Style="{StaticResource DeleteFilesCheckBoxStyle}"
 						    ToolTip="Delete files permanently, instead of moving them to the Reycling Bin." />
 						<CheckBox x:Name="RemoveFromLoadOrderCheckbox"
 						    Margin="8"
 						    HorizontalAlignment="Center"
 						    Content="Remove from Load Order"
+						    Style="{StaticResource DeleteFilesCheckBoxStyle}"
 						    ToolTip="Remove deleted mods from the active load order." />
 					</StackPanel>
-					<StackPanel Grid.Row="2" Orientation="Horizontal">
+					<StackPanel Grid.Row="1" HorizontalAlignment="Center" Orientation="Horizontal">
 						<Button x:Name="ConfirmButton"
 						    Margin="4,0"
-						    Padding="12,2"
-						    Content="Delete" />
+						    Content="Delete"
+						    Style="{StaticResource DeleteFilesPrimaryButtonStyle}" />
 						<Button x:Name="CancelButton"
 						    Margin="4,0"
-						    Padding="12,2"
-						    Content="Cancel" />
+						    Content="Cancel"
+						    Style="{StaticResource DeleteFilesButtonStyle}" />
 					</StackPanel>
 				</Grid>
 			</Grid>

--- a/src/GUI/Views/HorizontalModLayout.xaml
+++ b/src/GUI/Views/HorizontalModLayout.xaml
@@ -5,8 +5,10 @@
 	xmlns:adonisUI="clr-namespace:AdonisUI;assembly=AdonisUI"
 	xmlns:behavior="clr-namespace:DivinityModManager.Controls.Behavior"
 	xmlns:c="clr-namespace:DivinityModManager.Controls"
+	xmlns:conv="clr-namespace:DivinityModManager.Converters"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:data="clr-namespace:DivinityModManager.Models;assembly=DivinityModManagerCore"
+	xmlns:dapp="clr-namespace:DivinityModManager;assembly=DivinityModManagerCore"
 	xmlns:dd="urn:gong-wpf-dragdrop"
 	xmlns:local="clr-namespace:DivinityModManager.Views"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,6 +23,8 @@
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="../Themes/MainResourceDictionary.xaml" />
 			</ResourceDictionary.MergedDictionaries>
+			<conv:ModDetailsMediaWidthConverter x:Key="ModDetailsMediaWidthConverter" />
+			<conv:NexusDescriptionToPlainTextConverter x:Key="NexusDescriptionToPlainTextConverter" />
 			<Style x:Key="ListViewItemMouseEvents" BasedOn="{StaticResource DivinityModDataListItem}" TargetType="{x:Type ListViewItem}">
 				<!--<EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_ModifySelection" />-->
 			</Style>
@@ -146,15 +150,52 @@
 				<Setter Property="BorderThickness" Value="1" />
 				<Setter Property="CornerRadius" Value="6" />
 			</Style>
+			<Style x:Key="ModDetailsSourceButtonStyle" TargetType="{x:Type Button}">
+				<Setter Property="Height" Value="27" />
+				<Setter Property="Margin" Value="0,0,6,5" />
+				<Setter Property="Padding" Value="9,3" />
+				<Setter Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="Cursor" Value="Hand" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxAccentHoverBrush}" />
+				<Setter Property="FontWeight" Value="SemiBold" />
+				<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type Button}">
+							<Border x:Name="SourceButtonSurface"
+								Padding="{TemplateBinding Padding}"
+								Background="{TemplateBinding Background}"
+								BorderBrush="{TemplateBinding BorderBrush}"
+								BorderThickness="{TemplateBinding BorderThickness}"
+								CornerRadius="6">
+								<ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+							</Border>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter TargetName="SourceButtonSurface" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+									<Setter TargetName="SourceButtonSurface" Property="BorderBrush" Value="{DynamicResource ReduxAccentHoverBrush}" />
+								</Trigger>
+								<Trigger Property="IsPressed" Value="True">
+									<Setter TargetName="SourceButtonSurface" Property="Opacity" Value="0.75" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
 			<DataTemplate x:Key="ModDetailsOverviewTemplate" DataType="{x:Type data:DivinityModData}">
 				<Grid Margin="14,10">
 					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="250" />
+						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="14" />
 						<ColumnDefinition Width="*" />
 					</Grid.ColumnDefinitions>
-					<Border Height="170"
-						VerticalAlignment="Top"
+					<Border MinWidth="250"
+						MaxWidth="620"
+						Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}, Converter={StaticResource ModDetailsMediaWidthConverter}}"
+						VerticalAlignment="Stretch"
 						Background="{DynamicResource ReduxListInteriorBrush}"
 						BorderBrush="{DynamicResource ReduxBorderBrush}"
 						BorderThickness="1"
@@ -162,8 +203,8 @@
 						CornerRadius="7">
 						<Grid>
 							<Grid.RowDefinitions>
-								<RowDefinition Height="141" />
 								<RowDefinition Height="*" />
+								<RowDefinition Height="29" />
 							</Grid.RowDefinitions>
 							<!--  Future linked artwork belongs in this layer. Uniform preserves the complete image without aggressive cropping.  -->
 							<Image x:Name="ModDetailsPreviewImage"
@@ -171,9 +212,21 @@
 								HorizontalAlignment="Stretch"
 								VerticalAlignment="Stretch"
 								IsHitTestVisible="False"
+								RenderOptions.BitmapScalingMode="HighQuality"
+								Source="{Binding NexusModsData.PictureUrl, Converter={StaticResource UriToBitmapImageConverter}}"
 								Stretch="Uniform"
-								Visibility="Collapsed" />
+								Visibility="{Binding NexusImageVisibility}" />
 							<Grid x:Name="ModDetailsLocalPreviewPlaceholder">
+								<Grid.Style>
+									<Style TargetType="{x:Type Grid}">
+										<Setter Property="Visibility" Value="Visible" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding NexusImageVisibility}" Value="Visible">
+												<Setter Property="Visibility" Value="Collapsed" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</Grid.Style>
 								<StackPanel MaxWidth="205"
 									Margin="8"
 									HorizontalAlignment="Center"
@@ -214,9 +267,20 @@
 								<TextBlock HorizontalAlignment="Center"
 									VerticalAlignment="Center"
 									FontSize="10"
-									FontWeight="SemiBold"
-									Foreground="{DynamicResource ReduxTextSecondaryBrush}"
-									Text="LOCAL METADATA" />
+									FontWeight="SemiBold">
+									<TextBlock.Style>
+										<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+											<Setter Property="Foreground" Value="{DynamicResource ReduxTextSecondaryBrush}" />
+											<Setter Property="Text" Value="LOCAL METADATA" />
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding OpenNexusModsLinkVisibility}" Value="Visible">
+													<Setter Property="Foreground" Value="{DynamicResource ReduxAccentHoverBrush}" />
+													<Setter Property="Text" Value="NEXUS MODS" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</TextBlock.Style>
+								</TextBlock>
 							</Border>
 						</Grid>
 					</Border>
@@ -230,22 +294,80 @@
 						<TextBlock FontSize="20"
 							FontWeight="Bold"
 							Foreground="{DynamicResource ReduxTextPrimaryBrush}"
-							Text="{Binding DisplayName}"
-							TextTrimming="CharacterEllipsis" />
+							TextTrimming="CharacterEllipsis">
+							<TextBlock.Style>
+								<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+									<Setter Property="Text" Value="{Binding DisplayName}" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+											<Setter Property="Text" Value="{Binding NexusModsData.Name}" />
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
 						<TextBlock Grid.Row="1"
 							Margin="0,2,0,0"
-							Foreground="{DynamicResource ReduxTextMutedBrush}"
-							Text="Selected mod details" />
+							Foreground="{DynamicResource ReduxTextMutedBrush}">
+							<TextBlock.Style>
+								<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+									<Setter Property="Text" Value="Selected mod details" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+											<Setter Property="Text" Value="Automatically linked from Nexus Mods" />
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
 						<WrapPanel Grid.Row="2" Margin="0,7,0,0">
 							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
-								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding DisplayVersion, StringFormat='Version {0}'}" />
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}">
+									<TextBlock.Style>
+										<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+											<Setter Property="Text" Value="{Binding DisplayVersion, StringFormat='Version {0}'}" />
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+													<Setter Property="Text" Value="{Binding NexusModsData.Version, StringFormat='Nexus version {0}'}" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</TextBlock.Style>
+								</TextBlock>
 							</Border>
 							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
-								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding Author, StringFormat='By {0}'}" />
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}">
+									<TextBlock.Style>
+										<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+											<Setter Property="Text" Value="{Binding Author, StringFormat='By {0}'}" />
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+													<Setter Property="Text" Value="{Binding NexusModsData.Author, StringFormat='By {0}'}" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</TextBlock.Style>
+								</TextBlock>
 							</Border>
 							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
-								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding LastModifiedDateText}" />
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}">
+									<TextBlock.Style>
+										<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+											<Setter Property="Text" Value="{Binding LastModifiedDateText}" />
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+													<Setter Property="Text" Value="{Binding NexusModsUpdatedDate, StringFormat='Nexus updated {0:d}'}" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</TextBlock.Style>
+								</TextBlock>
 							</Border>
+							<Button Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+								CommandParameter="{Binding}"
+								Content="View Mod on Nexus Mods"
+								Style="{StaticResource ModDetailsSourceButtonStyle}"
+								Visibility="{Binding OpenNexusModsLinkVisibility}" />
 						</WrapPanel>
 						<Border Grid.Row="3"
 							Margin="0,3,0,0"
@@ -267,9 +389,18 @@
 									Margin="0,4,0,0"
 									HorizontalScrollBarVisibility="Disabled"
 									VerticalScrollBarVisibility="Auto">
-									<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}"
-										Text="{Binding Description, TargetNullValue='No local description is available.'}"
-										TextWrapping="Wrap" />
+									<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" TextWrapping="Wrap">
+										<TextBlock.Style>
+											<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+												<Setter Property="Text" Value="{Binding Description, TargetNullValue='No local description is available.'}" />
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+														<Setter Property="Text" Value="{Binding NexusModsData.Summary, TargetNullValue='No Nexus Mods summary is available.'}" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</TextBlock.Style>
+									</TextBlock>
 								</ScrollViewer>
 							</Grid>
 						</Border>
@@ -277,19 +408,72 @@
 				</Grid>
 			</DataTemplate>
 			<DataTemplate x:Key="ModDetailsDescriptionTemplate" DataType="{x:Type data:DivinityModData}">
-				<Grid Margin="18,14">
+				<Grid Margin="18,12">
 					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="*" />
 					</Grid.RowDefinitions>
-					<TextBlock FontSize="16" FontWeight="SemiBold" Text="Local description" />
-					<ScrollViewer Grid.Row="1"
-						Margin="0,8,0,0"
-						HorizontalScrollBarVisibility="Disabled"
-						VerticalScrollBarVisibility="Auto">
-						<TextBlock Text="{Binding Description, TargetNullValue='No local description is available for this mod.'}"
-							TextWrapping="Wrap" />
-					</ScrollViewer>
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+						<TextBlock FontSize="16" FontWeight="SemiBold">
+							<TextBlock.Style>
+								<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+									<Setter Property="Text" Value="Local description" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+											<Setter Property="Text" Value="Description from Nexus Mods" />
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
+						<Button Grid.Column="1"
+							Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+							CommandParameter="{Binding}"
+							Content="Open original page"
+							Style="{StaticResource ModDetailsSourceButtonStyle}"
+							Visibility="{Binding OpenNexusModsLinkVisibility}" />
+					</Grid>
+					<TextBlock Grid.Row="1"
+						Margin="0,2,0,0"
+						Foreground="{DynamicResource ReduxTextMutedBrush}">
+						<TextBlock.Style>
+							<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+								<Setter Property="Text" Value="Description stored inside the installed mod package." />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+										<Setter Property="Text" Value="Readable plain-text view. Open the original page for the author's full formatting and links." />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</TextBlock.Style>
+					</TextBlock>
+					<Border Grid.Row="2"
+						Margin="0,9,0,0"
+						Padding="12,10"
+						Background="{DynamicResource ReduxListInteriorBrush}"
+						BorderBrush="{DynamicResource ReduxBorderBrush}"
+						BorderThickness="1"
+						CornerRadius="7">
+						<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+							<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" TextWrapping="Wrap">
+								<TextBlock.Style>
+									<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+										<Setter Property="Text" Value="{Binding Description, TargetNullValue='No local description is available for this mod.'}" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+												<Setter Property="Text" Value="{Binding NexusModsData.Description, Converter={StaticResource NexusDescriptionToPlainTextConverter}}" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</TextBlock.Style>
+							</TextBlock>
+						</ScrollViewer>
+					</Border>
 				</Grid>
 			</DataTemplate>
 			<DataTemplate x:Key="ModDetailsFilesTemplate" DataType="{x:Type data:DivinityModData}">
@@ -316,6 +500,75 @@
 						<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="File path" />
 						<TextBlock Grid.Column="1" Text="{Binding FilePath}" TextTrimming="CharacterEllipsis" ToolTip="{Binding FilePath}" />
 					</Grid>
+				</Grid>
+			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsChangelogTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="18,12">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+						<TextBlock FontSize="16" FontWeight="SemiBold">
+							<TextBlock.Style>
+								<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+									<Setter Property="Text" Value="No online changelog linked" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+											<Setter Property="Text" Value="Changelog from Nexus Mods" />
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
+						<Button Grid.Column="1"
+							Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+							CommandParameter="{Binding}"
+							Content="Open original page"
+							Style="{StaticResource ModDetailsSourceButtonStyle}"
+							Visibility="{Binding OpenNexusModsLinkVisibility}" />
+					</Grid>
+					<TextBlock Grid.Row="1"
+						Margin="0,2,0,0"
+						Foreground="{DynamicResource ReduxTextMutedBrush}">
+						<TextBlock.Style>
+							<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+								<Setter Property="Text" Value="Version history will appear here after an online source is linked." />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+										<Setter Property="Text" Value="Cached version history from the linked Nexus Mods page." />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</TextBlock.Style>
+					</TextBlock>
+					<Border Grid.Row="2"
+						Margin="0,9,0,0"
+						Padding="12,10"
+						Background="{DynamicResource ReduxListInteriorBrush}"
+						BorderBrush="{DynamicResource ReduxBorderBrush}"
+						BorderThickness="1"
+						CornerRadius="7">
+						<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+							<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" TextWrapping="Wrap">
+								<TextBlock.Style>
+									<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+										<Setter Property="Text" Value="No online changelog is linked to this installed mod." />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding NexusModsInformationVisibility}" Value="Visible">
+												<Setter Property="Text" Value="{Binding NexusModsData.ChangelogText, Converter={StaticResource NexusDescriptionToPlainTextConverter}, ConverterParameter='No Nexus Mods changelog is available for this mod.'}" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</TextBlock.Style>
+							</TextBlock>
+						</ScrollViewer>
+					</Border>
 				</Grid>
 			</DataTemplate>
 			<DataTemplate x:Key="ModDetailsTabbedTemplate" DataType="{x:Type data:DivinityModData}">
@@ -354,15 +607,7 @@
 						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsFilesTemplate}" />
 					</TabItem>
 					<TabItem Header="Changelog">
-						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
-							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No changelog linked" />
-							<TextBlock MaxWidth="520"
-								Margin="0,6,0,0"
-								Foreground="{DynamicResource ReduxTextMutedBrush}"
-								Text="Version history from Nexus Mods or mod.io will appear here after an online source is linked."
-								TextAlignment="Center"
-								TextWrapping="Wrap" />
-						</StackPanel>
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsChangelogTemplate}" />
 					</TabItem>
 				</TabControl>
 			</DataTemplate>
@@ -373,8 +618,9 @@
 	</UserControl.Style>
 	<Grid>
 		<Grid.RowDefinitions>
-			<RowDefinition Height="*" />
-			<RowDefinition Height="Auto" />
+			<RowDefinition x:Name="ModListsRow" Height="*" MinHeight="180" />
+			<RowDefinition x:Name="ModDetailsSplitterRow" Height="0" />
+			<RowDefinition x:Name="ModDetailsRow" Height="0" />
 		</Grid.RowDefinitions>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
@@ -461,6 +707,7 @@
 					dd:DragDrop.DragHandler="{Binding DragHandler}"
 					dd:DragDrop.DropHandler="{Binding DropHandler}"
 					GridViewColumnHeader.Click="ListView_Click"
+					GridViewColumnHeader.PreviewMouseRightButtonUp="ListViewColumnHeader_RightClick"
 					ItemContainerStyle="{StaticResource ListViewItemMouseEvents}"
 					Style="{StaticResource ModOrderListViewWithDrag}"
 					View="{DynamicResource ModGridView}"
@@ -571,6 +818,7 @@
 				dd:DragDrop.DragHandler="{Binding DragHandler}"
 				dd:DragDrop.DropHandler="{Binding DropHandler}"
 				GridViewColumnHeader.Click="ListView_Click"
+				GridViewColumnHeader.PreviewMouseRightButtonUp="ListViewColumnHeader_RightClick"
 				ItemContainerStyle="{StaticResource ListViewItemMouseEvents}"
 				Style="{StaticResource ModOrderListViewWithDrag}"
 				View="{DynamicResource InactiveModGridView}"
@@ -578,21 +826,100 @@
 				VirtualizingPanel.VirtualizationMode="Recycling" />
 		</Grid>
 		</Border>
-		<Border x:Name="ModDetailsPanel"
+		<GridSplitter x:Name="ModDetailsGridSplitter"
 			Grid.Row="1"
+			Grid.ColumnSpan="3"
+			Height="6"
+			HorizontalAlignment="Stretch"
+			VerticalAlignment="Stretch"
+			Background="Transparent"
+			Cursor="SizeNS"
+			ResizeBehavior="PreviousAndNext"
+			ResizeDirection="Rows"
+			ShowsPreview="True"
+			Visibility="Collapsed">
+			<GridSplitter.PreviewStyle>
+				<Style TargetType="{x:Type Control}">
+					<Setter Property="Template">
+						<Setter.Value>
+							<ControlTemplate TargetType="{x:Type Control}">
+								<Border Height="3"
+									Margin="10,0"
+									VerticalAlignment="Center"
+									Background="{DynamicResource ReduxAccentHoverBrush}"
+									CornerRadius="2">
+									<Border.Effect>
+										<DropShadowEffect BlurRadius="10"
+											Color="{DynamicResource ReduxAccentHoverColor}"
+											Opacity="0.9"
+											ShadowDepth="0" />
+									</Border.Effect>
+								</Border>
+							</ControlTemplate>
+						</Setter.Value>
+					</Setter>
+				</Style>
+			</GridSplitter.PreviewStyle>
+			<GridSplitter.Template>
+				<ControlTemplate TargetType="{x:Type GridSplitter}">
+					<Grid Background="Transparent">
+						<Border x:Name="RestingHandle"
+							Width="64"
+							Height="2"
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							Background="{DynamicResource ReduxBorderStrongBrush}"
+							CornerRadius="1" />
+						<Border x:Name="InteractionGlow"
+							Width="96"
+							Height="3"
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							Background="{DynamicResource ReduxAccentHoverBrush}"
+							CornerRadius="2"
+							Opacity="0">
+							<Border.Effect>
+								<DropShadowEffect BlurRadius="8"
+									Color="{DynamicResource ReduxAccentHoverColor}"
+									Opacity="0.8"
+									ShadowDepth="0" />
+							</Border.Effect>
+						</Border>
+					</Grid>
+					<ControlTemplate.Triggers>
+						<EventTrigger RoutedEvent="MouseEnter">
+							<BeginStoryboard>
+								<Storyboard>
+									<DoubleAnimation Storyboard.TargetName="InteractionGlow"
+										Storyboard.TargetProperty="Opacity"
+										To="0.9"
+										Duration="0:0:0.14" />
+								</Storyboard>
+							</BeginStoryboard>
+						</EventTrigger>
+						<EventTrigger RoutedEvent="MouseLeave">
+							<BeginStoryboard>
+								<Storyboard>
+									<DoubleAnimation Storyboard.TargetName="InteractionGlow"
+										Storyboard.TargetProperty="Opacity"
+										To="0"
+										Duration="0:0:0.18" />
+								</Storyboard>
+							</BeginStoryboard>
+						</EventTrigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</GridSplitter.Template>
+		</GridSplitter>
+		<Border x:Name="ModDetailsPanel"
+			Grid.Row="2"
 			Grid.ColumnSpan="3"
 			Margin="10,0,10,10"
 			Visibility="Collapsed">
 			<Border.Style>
 				<Style BasedOn="{StaticResource ModSectionCard}" TargetType="{x:Type Border}">
-					<Setter Property="Height" Value="285" />
 					<Setter Property="Background" Value="{DynamicResource ReduxSurfaceBrush}" />
 					<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
-					<Style.Triggers>
-						<DataTrigger Binding="{Binding IsChecked, ElementName=ModDetailsToggleButton}" Value="False">
-							<Setter Property="Height" Value="48" />
-						</DataTrigger>
-					</Style.Triggers>
 				</Style>
 			</Border.Style>
 			<Grid>

--- a/src/GUI/Views/HorizontalModLayout.xaml
+++ b/src/GUI/Views/HorizontalModLayout.xaml
@@ -502,6 +502,145 @@
 					</Grid>
 				</Grid>
 			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsMediaTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="18,12">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+						<TextBlock FontSize="16" FontWeight="SemiBold">
+							<TextBlock.Style>
+								<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+									<Setter Property="Text" Value="No linked media yet" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding NexusImageVisibility}" Value="Visible">
+											<Setter Property="Text" Value="Media from Nexus Mods" />
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
+						<Button Grid.Column="1"
+							Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+							CommandParameter="{Binding}"
+							Content="View Mod on Nexus Mods"
+							Style="{StaticResource ModDetailsSourceButtonStyle}"
+							Visibility="{Binding OpenNexusModsLinkVisibility}" />
+					</Grid>
+					<TextBlock Grid.Row="1"
+						Margin="0,2,0,0"
+						Foreground="{DynamicResource ReduxTextMutedBrush}">
+						<TextBlock.Style>
+							<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+								<Setter Property="Text" Value="Images from Nexus Mods or mod.io will appear here after an online source is linked." />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding NexusImageVisibility}" Value="Visible">
+										<Setter Property="Text" Value="The linked source image is shown without cropping." />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</TextBlock.Style>
+					</TextBlock>
+					<Border Grid.Row="2"
+						MinHeight="120"
+						Margin="0,9,0,0"
+						Padding="8"
+						Background="{DynamicResource ReduxListInteriorBrush}"
+						BorderBrush="{DynamicResource ReduxBorderBrush}"
+						BorderThickness="1"
+						CornerRadius="7">
+						<Grid>
+							<Image HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								IsHitTestVisible="False"
+								RenderOptions.BitmapScalingMode="HighQuality"
+								Source="{Binding NexusModsData.PictureUrl, Converter={StaticResource UriToBitmapImageConverter}}"
+								Stretch="Uniform"
+								Visibility="{Binding NexusImageVisibility}" />
+							<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+								<StackPanel.Style>
+									<Style TargetType="StackPanel">
+										<Setter Property="Visibility" Value="Visible" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding NexusImageVisibility}" Value="Visible">
+												<Setter Property="Visibility" Value="Collapsed" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</StackPanel.Style>
+								<TextBlock HorizontalAlignment="Center" FontWeight="SemiBold" Text="No image available" />
+								<TextBlock MaxWidth="520"
+									Margin="0,5,0,0"
+									Foreground="{DynamicResource ReduxTextMutedBrush}"
+									Text="Local metadata remains available while Redux looks for a linked online source."
+									TextAlignment="Center"
+									TextWrapping="Wrap" />
+							</StackPanel>
+						</Grid>
+					</Border>
+				</Grid>
+			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsRequirementsTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="18,12">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<TextBlock FontSize="16" FontWeight="SemiBold" Text="Installed mod dependencies" />
+					<TextBlock Grid.Row="1"
+						Margin="0,2,0,0"
+						Foreground="{DynamicResource ReduxTextMutedBrush}"
+						Text="Dependencies parsed from the installed mod package. Online requirements can be added when a source provides them." />
+					<Border Grid.Row="2"
+						Margin="0,9,0,0"
+						Padding="10"
+						Background="{DynamicResource ReduxListInteriorBrush}"
+						BorderBrush="{DynamicResource ReduxBorderBrush}"
+						BorderThickness="1"
+						CornerRadius="7">
+						<Grid>
+							<ListBox ItemTemplate="{StaticResource DependencyModTemplate}"
+								ItemsSource="{Binding DisplayedDependencies}">
+								<ListBox.Style>
+									<Style BasedOn="{StaticResource ModuleShortDescListBox}" TargetType="ListBox">
+										<Setter Property="Visibility" Value="Visible" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding HasDependencies}" Value="False">
+												<Setter Property="Visibility" Value="Collapsed" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</ListBox.Style>
+							</ListBox>
+							<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+								<StackPanel.Style>
+									<Style TargetType="StackPanel">
+										<Setter Property="Visibility" Value="Collapsed" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding HasDependencies}" Value="False">
+												<Setter Property="Visibility" Value="Visible" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</StackPanel.Style>
+								<TextBlock HorizontalAlignment="Center" FontWeight="SemiBold" Text="No installed dependencies declared" />
+								<TextBlock Margin="0,5,0,0"
+									Foreground="{DynamicResource ReduxTextMutedBrush}"
+									Text="This mod's local metadata does not list another mod as a dependency."
+									TextAlignment="Center"
+									TextWrapping="Wrap" />
+							</StackPanel>
+						</Grid>
+					</Border>
+				</Grid>
+			</DataTemplate>
 			<DataTemplate x:Key="ModDetailsChangelogTemplate" DataType="{x:Type data:DivinityModData}">
 				<Grid Margin="18,12">
 					<Grid.RowDefinitions>
@@ -527,9 +666,9 @@
 							</TextBlock.Style>
 						</TextBlock>
 						<Button Grid.Column="1"
-							Command="{Binding Path=OpenNexusModsPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
+							Command="{Binding Path=OpenNexusModsChangelogPageCommand, Source={x:Static dapp:DivinityApp.Commands}}"
 							CommandParameter="{Binding}"
-							Content="Open original page"
+							Content="Open Nexus changelog page"
 							Style="{StaticResource ModDetailsSourceButtonStyle}"
 							Visibility="{Binding OpenNexusModsLinkVisibility}" />
 					</Grid>
@@ -579,29 +718,13 @@
 						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsOverviewTemplate}" />
 					</TabItem>
 					<TabItem Header="Media">
-						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
-							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No linked media yet" />
-							<TextBlock MaxWidth="520"
-								Margin="0,6,0,0"
-								Foreground="{DynamicResource ReduxTextMutedBrush}"
-								Text="Images from Nexus Mods or mod.io will appear here after an online source is linked."
-								TextAlignment="Center"
-								TextWrapping="Wrap" />
-						</StackPanel>
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsMediaTemplate}" />
 					</TabItem>
 					<TabItem Header="Description">
 						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsDescriptionTemplate}" />
 					</TabItem>
 					<TabItem Header="Requirements">
-						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
-							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No dependency information available" />
-							<TextBlock MaxWidth="560"
-								Margin="0,6,0,0"
-								Foreground="{DynamicResource ReduxTextMutedBrush}"
-								Text="Author-supplied requirements and compatibility notes can appear here after an online source is linked."
-								TextAlignment="Center"
-								TextWrapping="Wrap" />
-						</StackPanel>
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsRequirementsTemplate}" />
 					</TabItem>
 					<TabItem Header="Files">
 						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsFilesTemplate}" />

--- a/src/GUI/Views/HorizontalModLayout.xaml
+++ b/src/GUI/Views/HorizontalModLayout.xaml
@@ -1,6 +1,7 @@
 <local:HorizontalModLayoutBase x:Class="DivinityModManager.Views.HorizontalModLayout"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:adonisExtensions="clr-namespace:AdonisUI.Extensions;assembly=AdonisUI"
 	xmlns:adonisUI="clr-namespace:AdonisUI;assembly=AdonisUI"
 	xmlns:behavior="clr-namespace:DivinityModManager.Controls.Behavior"
 	xmlns:c="clr-namespace:DivinityModManager.Controls"
@@ -28,51 +29,398 @@
 				<Setter Property="dd:DragDrop.IsDragSource" Value="True" />
 				<Setter Property="dd:DragDrop.IsDropTarget" Value="True" />
 			</Style>
+			<Style x:Key="ModSectionCard" TargetType="{x:Type Border}">
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="CornerRadius" Value="8" />
+				<Setter Property="ClipToBounds" Value="True" />
+			</Style>
+			<Style x:Key="ModSectionTitle" BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+				<Setter Property="FontSize" Value="14" />
+				<Setter Property="FontWeight" Value="SemiBold" />
+			</Style>
+			<Style x:Key="ModDetailsToggleStyle" TargetType="{x:Type ToggleButton}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="BorderThickness" Value="0" />
+				<Setter Property="Cursor" Value="Hand" />
+				<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type ToggleButton}">
+							<Border Padding="8,3" Background="Transparent" CornerRadius="4">
+								<TextBlock x:Name="ToggleGlyph"
+									FontFamily="Segoe UI Symbol"
+									FontSize="16"
+									Foreground="{TemplateBinding Foreground}"
+									Text="⌃" />
+							</Border>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsChecked" Value="False">
+									<Setter TargetName="ToggleGlyph" Property="Text" Value="⌄" />
+								</Trigger>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter Property="Foreground" Value="{DynamicResource ReduxAccentBrush}" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<Style x:Key="ModDetailsTabControlStyle" TargetType="{x:Type TabControl}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="BorderThickness" Value="0" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type TabControl}">
+							<Grid KeyboardNavigation.TabNavigation="Local">
+								<Grid.RowDefinitions>
+								<RowDefinition Height="40" />
+									<RowDefinition Height="1" />
+									<RowDefinition Height="*" />
+								</Grid.RowDefinitions>
+							<TabPanel Margin="14,2,14,0"
+									IsItemsHost="True"
+									KeyboardNavigation.TabIndex="1" />
+								<Border Grid.Row="1"
+									Height="1"
+									Background="{DynamicResource ReduxBorderBrush}" />
+								<ContentPresenter x:Name="PART_SelectedContentHost"
+									Grid.Row="2"
+									ContentSource="SelectedContent"
+									KeyboardNavigation.DirectionalNavigation="Contained"
+									SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+									TextElement.Foreground="{DynamicResource ReduxTextPrimaryBrush}" />
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<Style x:Key="ModDetailsTabItemStyle" TargetType="{x:Type TabItem}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="BorderBrush" Value="Transparent" />
+				<Setter Property="BorderThickness" Value="0,0,0,2" />
+				<Setter Property="Cursor" Value="Hand" />
+				<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Margin" Value="0,0,4,0" />
+				<Setter Property="MinWidth" Value="86" />
+				<Setter Property="Padding" Value="12,7" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type TabItem}">
+							<Border x:Name="TabBorder"
+								Padding="{TemplateBinding Padding}"
+								Background="{TemplateBinding Background}"
+								BorderBrush="{TemplateBinding BorderBrush}"
+								BorderThickness="{TemplateBinding BorderThickness}"
+								CornerRadius="6,6,0,0">
+								<TextBlock x:Name="HeaderText"
+									HorizontalAlignment="Center"
+									VerticalAlignment="Center"
+									Foreground="{DynamicResource ReduxTextMutedBrush}"
+									Text="{TemplateBinding Header}" />
+							</Border>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter TargetName="TabBorder" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+									<Setter TargetName="HeaderText" Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+								</Trigger>
+								<Trigger Property="IsSelected" Value="True">
+									<Setter Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+									<Setter Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+									<Setter TargetName="HeaderText" Property="Foreground" Value="{DynamicResource ReduxAccentHoverBrush}" />
+									<Setter TargetName="HeaderText" Property="FontWeight" Value="SemiBold" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<Style x:Key="ModDetailsMetadataChipStyle" TargetType="{x:Type Border}">
+				<Setter Property="Margin" Value="0,0,6,5" />
+				<Setter Property="Padding" Value="8,3" />
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="CornerRadius" Value="6" />
+			</Style>
+			<DataTemplate x:Key="ModDetailsOverviewTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="14,10">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="250" />
+						<ColumnDefinition Width="14" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<Border Height="170"
+						VerticalAlignment="Top"
+						Background="{DynamicResource ReduxListInteriorBrush}"
+						BorderBrush="{DynamicResource ReduxBorderBrush}"
+						BorderThickness="1"
+						ClipToBounds="True"
+						CornerRadius="7">
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="141" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+							<!--  Future linked artwork belongs in this layer. Uniform preserves the complete image without aggressive cropping.  -->
+							<Image x:Name="ModDetailsPreviewImage"
+								Margin="6"
+								HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								IsHitTestVisible="False"
+								Stretch="Uniform"
+								Visibility="Collapsed" />
+							<Grid x:Name="ModDetailsLocalPreviewPlaceholder">
+								<StackPanel MaxWidth="205"
+									Margin="8"
+									HorizontalAlignment="Center"
+									VerticalAlignment="Center">
+									<Border Width="64"
+										Height="34"
+										HorizontalAlignment="Center"
+										Background="{DynamicResource ReduxAccentSoftBrush}"
+										BorderBrush="{DynamicResource ReduxAccentBrush}"
+										BorderThickness="1"
+										CornerRadius="8">
+										<TextBlock HorizontalAlignment="Center"
+											VerticalAlignment="Center"
+											FontSize="15"
+											FontWeight="Bold"
+											Foreground="{DynamicResource ReduxAccentHoverBrush}"
+											Text="MOD" />
+									</Border>
+									<TextBlock Margin="0,6,0,0"
+										HorizontalAlignment="Center"
+										FontWeight="SemiBold"
+										Foreground="{DynamicResource ReduxTextSecondaryBrush}"
+										Text="No linked media" />
+									<TextBlock Margin="0,2,0,0"
+										HorizontalAlignment="Center"
+										Foreground="{DynamicResource ReduxTextMutedBrush}"
+										Text="Online source will appear here when linked."
+										TextAlignment="Center"
+										TextWrapping="Wrap" />
+								</StackPanel>
+							</Grid>
+							<Border Grid.Row="1"
+								Margin="6,0,6,6"
+								Background="{DynamicResource ReduxSurfaceMutedBrush}"
+								BorderBrush="{DynamicResource ReduxBorderBrush}"
+								BorderThickness="1"
+								CornerRadius="5">
+								<TextBlock HorizontalAlignment="Center"
+									VerticalAlignment="Center"
+									FontSize="10"
+									FontWeight="SemiBold"
+									Foreground="{DynamicResource ReduxTextSecondaryBrush}"
+									Text="LOCAL METADATA" />
+							</Border>
+						</Grid>
+					</Border>
+					<Grid Grid.Column="2">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="*" />
+						</Grid.RowDefinitions>
+						<TextBlock FontSize="20"
+							FontWeight="Bold"
+							Foreground="{DynamicResource ReduxTextPrimaryBrush}"
+							Text="{Binding DisplayName}"
+							TextTrimming="CharacterEllipsis" />
+						<TextBlock Grid.Row="1"
+							Margin="0,2,0,0"
+							Foreground="{DynamicResource ReduxTextMutedBrush}"
+							Text="Selected mod details" />
+						<WrapPanel Grid.Row="2" Margin="0,7,0,0">
+							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding DisplayVersion, StringFormat='Version {0}'}" />
+							</Border>
+							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding Author, StringFormat='By {0}'}" />
+							</Border>
+							<Border Style="{StaticResource ModDetailsMetadataChipStyle}">
+								<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="{Binding LastModifiedDateText}" />
+							</Border>
+						</WrapPanel>
+						<Border Grid.Row="3"
+							Margin="0,3,0,0"
+							Padding="10,8"
+							Background="{DynamicResource ReduxListInteriorBrush}"
+							BorderBrush="{DynamicResource ReduxBorderBrush}"
+							BorderThickness="1"
+							CornerRadius="7">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="*" />
+								</Grid.RowDefinitions>
+								<TextBlock FontSize="11"
+									FontWeight="SemiBold"
+									Foreground="{DynamicResource ReduxTextMutedBrush}"
+									Text="SUMMARY" />
+								<ScrollViewer Grid.Row="1"
+									Margin="0,4,0,0"
+									HorizontalScrollBarVisibility="Disabled"
+									VerticalScrollBarVisibility="Auto">
+									<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}"
+										Text="{Binding Description, TargetNullValue='No local description is available.'}"
+										TextWrapping="Wrap" />
+								</ScrollViewer>
+							</Grid>
+						</Border>
+					</Grid>
+				</Grid>
+			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsDescriptionTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="18,14">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<TextBlock FontSize="16" FontWeight="SemiBold" Text="Local description" />
+					<ScrollViewer Grid.Row="1"
+						Margin="0,8,0,0"
+						HorizontalScrollBarVisibility="Disabled"
+						VerticalScrollBarVisibility="Auto">
+						<TextBlock Text="{Binding Description, TargetNullValue='No local description is available for this mod.'}"
+							TextWrapping="Wrap" />
+					</ScrollViewer>
+				</Grid>
+			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsFilesTemplate" DataType="{x:Type data:DivinityModData}">
+				<Grid Margin="18,14">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+					<TextBlock FontSize="16" FontWeight="SemiBold" Text="Installed package" />
+					<Grid Grid.Row="1" Margin="0,10,0,0">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="80" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="Mod UUID" />
+						<TextBlock Grid.Column="1" Text="{Binding UUID}" TextTrimming="CharacterEllipsis" ToolTip="{Binding UUID}" />
+					</Grid>
+					<Grid Grid.Row="2" Margin="0,8,0,0">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="80" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<TextBlock Foreground="{DynamicResource ReduxTextSecondaryBrush}" Text="File path" />
+						<TextBlock Grid.Column="1" Text="{Binding FilePath}" TextTrimming="CharacterEllipsis" ToolTip="{Binding FilePath}" />
+					</Grid>
+				</Grid>
+			</DataTemplate>
+			<DataTemplate x:Key="ModDetailsTabbedTemplate" DataType="{x:Type data:DivinityModData}">
+				<TabControl ItemContainerStyle="{StaticResource ModDetailsTabItemStyle}"
+					SelectedIndex="0"
+					Style="{StaticResource ModDetailsTabControlStyle}">
+					<TabItem Header="Overview">
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsOverviewTemplate}" />
+					</TabItem>
+					<TabItem Header="Media">
+						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
+							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No linked media yet" />
+							<TextBlock MaxWidth="520"
+								Margin="0,6,0,0"
+								Foreground="{DynamicResource ReduxTextMutedBrush}"
+								Text="Images from Nexus Mods or mod.io will appear here after an online source is linked."
+								TextAlignment="Center"
+								TextWrapping="Wrap" />
+						</StackPanel>
+					</TabItem>
+					<TabItem Header="Description">
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsDescriptionTemplate}" />
+					</TabItem>
+					<TabItem Header="Requirements">
+						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
+							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No dependency information available" />
+							<TextBlock MaxWidth="560"
+								Margin="0,6,0,0"
+								Foreground="{DynamicResource ReduxTextMutedBrush}"
+								Text="Author-supplied requirements and compatibility notes can appear here after an online source is linked."
+								TextAlignment="Center"
+								TextWrapping="Wrap" />
+						</StackPanel>
+					</TabItem>
+					<TabItem Header="Files">
+						<ContentControl Content="{Binding}" ContentTemplate="{StaticResource ModDetailsFilesTemplate}" />
+					</TabItem>
+					<TabItem Header="Changelog">
+						<StackPanel Margin="18,22" HorizontalAlignment="Center" VerticalAlignment="Center">
+							<TextBlock HorizontalAlignment="Center" FontSize="16" FontWeight="SemiBold" Text="No changelog linked" />
+							<TextBlock MaxWidth="520"
+								Margin="0,6,0,0"
+								Foreground="{DynamicResource ReduxTextMutedBrush}"
+								Text="Version history from Nexus Mods or mod.io will appear here after an online source is linked."
+								TextAlignment="Center"
+								TextWrapping="Wrap" />
+						</StackPanel>
+					</TabItem>
+				</TabControl>
+			</DataTemplate>
 		</ResourceDictionary>
 	</UserControl.Resources>
 	<UserControl.Style>
 		<Style BasedOn="{StaticResource {x:Type UserControl}}" TargetType="UserControl" />
 	</UserControl.Style>
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="4" />
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
-		<Grid Grid.Column="0" HorizontalAlignment="Stretch">
+		<Border Grid.Column="0"
+			Margin="10,4,5,10"
+			Style="{StaticResource ModSectionCard}">
+		<Grid HorizontalAlignment="Stretch">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
-			<Grid Margin="4,0,0,4">
+			<Grid Margin="12,10,12,8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="4" />
-					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="Auto" />
 					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="8" />
+					<ColumnDefinition Width="220" />
 				</Grid.ColumnDefinitions>
-				<TextBlock Padding="4" Text="Active Mods" />
-				<c:UnfocusableTextBox x:Name="ActiveModsFilterTextBox"
-					Grid.Column="1"
-					Width="200"
+				<TextBlock Style="{StaticResource ModSectionTitle}" Text="Active Mods" />
+			<c:UnfocusableTextBox x:Name="ActiveModsFilterTextBox"
+					Grid.Column="5"
+					Height="28"
 					Padding="4,0"
-					HorizontalAlignment="Left"
+					HorizontalAlignment="Stretch"
 					VerticalAlignment="Center"
 					behavior:ScreenReaderHelperBehavior.Name="Active Mods Filter"
 					AcceptsReturn="False"
 					AcceptsTab="False"
+					adonisExtensions:CornerRadiusExtension.CornerRadius="6"
+					Background="{DynamicResource ReduxSurfaceMutedBrush}"
+					BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
 					CanUndoTextOnEscape="True"
 					TextAlignment="Left"
 					ToolTip="Filter Active Mods"
 					UpdateBindingOnFocusLost="True" />
-				<TextBlock Grid.Column="1"
+				<TextBlock Grid.Column="5"
 					Margin="0"
 					Padding="4,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
-					Foreground="{DynamicResource {x:Static adonisUI:Brushes.DisabledForegroundBrush}}"
+					Foreground="{DynamicResource ReduxTextMutedBrush}"
 					IsHitTestVisible="False"
 					Text="Filter Active Mods">
 					<TextBlock.Style>
@@ -87,15 +435,15 @@
 					</TextBlock.Style>
 				</TextBlock>
 				<TextBlock x:Name="ActiveModsFilterResultText"
-					Grid.Column="3"
-					Margin="0"
+					Grid.Column="2"
+					Margin="0,0,8,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
 					behavior:ScreenReaderHelperBehavior.Name="Total Hidden Active Mods"
 					AutomationProperties.HelpText="{Binding Text, RelativeSource={RelativeSource Self}}" />
 				<TextBlock x:Name="ActiveSelectedText"
-					Grid.Column="4"
-					Margin="0"
+					Grid.Column="3"
+					Margin="0,0,8,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
 					AutomationProperties.HelpText="{Binding Text, RelativeSource={RelativeSource Self}}"
@@ -141,46 +489,52 @@
 				</Grid>
 			</Grid>
 		</Grid>
+		</Border>
 		<GridSplitter Grid.Column="1"
 			Width="4"
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch" />
-		<Grid x:Name="InactiveModListGrid" Grid.Column="2" HorizontalAlignment="Stretch">
+		<Border Grid.Column="2"
+			Margin="5,4,10,10"
+			Style="{StaticResource ModSectionCard}">
+		<Grid x:Name="InactiveModListGrid" HorizontalAlignment="Stretch">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="2" />
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
-			<Grid Margin="4,0,0,4">
+			<Grid Margin="12,10,12,8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="4" />
-					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="Auto" />
 					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="8" />
+					<ColumnDefinition Width="220" />
 				</Grid.ColumnDefinitions>
-				<TextBlock Padding="4" Text="Inactive Mods" />
-				<c:UnfocusableTextBox x:Name="InactiveModsFilterTextBox"
-					Grid.Column="1"
-					Width="200"
+				<TextBlock Style="{StaticResource ModSectionTitle}" Text="Inactive Mods" />
+			<c:UnfocusableTextBox x:Name="InactiveModsFilterTextBox"
+					Grid.Column="5"
+					Height="28"
 					Padding="4,0"
-					HorizontalAlignment="Left"
+					HorizontalAlignment="Stretch"
 					VerticalAlignment="Center"
 					behavior:ScreenReaderHelperBehavior.Name="Inactive Mods Filter"
 					AcceptsReturn="False"
 					AcceptsTab="False"
+					adonisExtensions:CornerRadiusExtension.CornerRadius="6"
+					Background="{DynamicResource ReduxSurfaceMutedBrush}"
+					BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
 					CanUndoTextOnEscape="True"
 					TextAlignment="Left"
 					ToolTip="Filter Inactive Mods"
 					UpdateBindingOnFocusLost="True" />
-				<TextBlock Grid.Column="1"
-					Width="200"
+				<TextBlock Grid.Column="5"
 					Margin="0"
 					Padding="4,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
-					Foreground="{DynamicResource {x:Static adonisUI:Brushes.DisabledForegroundBrush}}"
+					Foreground="{DynamicResource ReduxTextMutedBrush}"
 					IsHitTestVisible="False"
 					Text="Filter Inactive Mods">
 					<TextBlock.Style>
@@ -195,15 +549,15 @@
 					</TextBlock.Style>
 				</TextBlock>
 				<TextBlock x:Name="InactiveModsFilterResultText"
-					Grid.Column="3"
-					Margin="0"
+					Grid.Column="2"
+					Margin="0,0,8,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
 					behavior:ScreenReaderHelperBehavior.Name="Total Hidden Inactive Mods"
 					AutomationProperties.HelpText="{Binding Text, RelativeSource={RelativeSource Self}}" />
 				<TextBlock x:Name="InactiveSelectedText"
-					Grid.Column="4"
-					Margin="0"
+					Grid.Column="3"
+					Margin="0,0,8,0"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Center"
 					behavior:ScreenReaderHelperBehavior.Name="Total Inactive Mods Selected"
@@ -223,5 +577,77 @@
 				VirtualizingPanel.IsVirtualizing="True"
 				VirtualizingPanel.VirtualizationMode="Recycling" />
 		</Grid>
+		</Border>
+		<Border x:Name="ModDetailsPanel"
+			Grid.Row="1"
+			Grid.ColumnSpan="3"
+			Margin="10,0,10,10"
+			Visibility="Collapsed">
+			<Border.Style>
+				<Style BasedOn="{StaticResource ModSectionCard}" TargetType="{x:Type Border}">
+					<Setter Property="Height" Value="285" />
+					<Setter Property="Background" Value="{DynamicResource ReduxSurfaceBrush}" />
+					<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding IsChecked, ElementName=ModDetailsToggleButton}" Value="False">
+							<Setter Property="Height" Value="48" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</Border.Style>
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="46" />
+					<RowDefinition Height="*" />
+				</Grid.RowDefinitions>
+				<Grid Margin="12,0">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+					<Border Width="28"
+						Height="28"
+						Margin="0,0,10,0"
+						Background="{DynamicResource ReduxAccentSoftBrush}"
+						BorderBrush="{DynamicResource ReduxAccentBrush}"
+						BorderThickness="1"
+						CornerRadius="8">
+						<TextBlock HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							FontSize="12"
+							FontWeight="Bold"
+							Foreground="{DynamicResource ReduxAccentHoverBrush}"
+							Text="M" />
+					</Border>
+					<TextBlock Grid.Column="1"
+						VerticalAlignment="Center"
+						FontSize="15"
+						FontWeight="SemiBold"
+						Foreground="{DynamicResource ReduxTextPrimaryBrush}"
+						Text="{Binding Content.DisplayName, ElementName=ModDetailsContent, TargetNullValue='Selected Mod'}"
+						TextTrimming="CharacterEllipsis" />
+					<ToggleButton x:Name="ModDetailsToggleButton"
+						Grid.Column="2"
+						IsChecked="True"
+						Style="{StaticResource ModDetailsToggleStyle}"
+						ToolTip="Collapse or expand mod details" />
+				</Grid>
+				<ContentControl x:Name="ModDetailsContent"
+					Grid.Row="1"
+					ContentTemplate="{StaticResource ModDetailsTabbedTemplate}">
+					<ContentControl.Style>
+						<Style TargetType="{x:Type ContentControl}">
+							<Setter Property="Visibility" Value="Visible" />
+							<Style.Triggers>
+								<DataTrigger Binding="{Binding IsChecked, ElementName=ModDetailsToggleButton}" Value="False">
+									<Setter Property="Visibility" Value="Collapsed" />
+								</DataTrigger>
+							</Style.Triggers>
+						</Style>
+					</ContentControl.Style>
+				</ContentControl>
+			</Grid>
+		</Border>
 	</Grid>
 </local:HorizontalModLayoutBase>

--- a/src/GUI/Views/HorizontalModLayout.xaml.cs
+++ b/src/GUI/Views/HorizontalModLayout.xaml.cs
@@ -13,6 +13,7 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -38,7 +39,22 @@ public class HorizontalModLayoutBase : ReactiveUserControl<MainWindowViewModel> 
 /// </summary>
 public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayout
 {
+	private const double DefaultModDetailsRowHeight = 295;
+	private const double MinimumExpandedModDetailsRowHeight = 295;
+	private const double CollapsedModDetailsRowHeight = 58;
+	private const double ModDetailsSplitterHeight = 6;
+
 	private object _focusedList = null;
+	private double _lastExpandedModDetailsRowHeight = DefaultModDetailsRowHeight;
+	private readonly Dictionary<GridViewColumn, double> _visibleModListColumnWidths = new();
+	private static readonly string[] OptionalModListColumns =
+	[
+		"Version",
+		"Author",
+		"Last Updated",
+		"Last Modified",
+		"Source"
+	];
 
 	public ModListView ActiveModsView => ActiveModsListView;
 	public ModListView InactiveModsView => InactiveModsListView;
@@ -248,8 +264,64 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 		var selectedMod = e?.AddedItems?.OfType<DivinityModData>().LastOrDefault()
 			?? GetSelectedModForDetails();
 
+		if (selectedMod == null)
+		{
+			RememberExpandedModDetailsHeight();
+		}
+
 		ModDetailsContent.Content = selectedMod;
 		ModDetailsPanel.Visibility = selectedMod != null ? Visibility.Visible : Visibility.Collapsed;
+		UpdateModDetailsLayout(selectedMod != null);
+	}
+
+	private void RememberExpandedModDetailsHeight()
+	{
+		if (ModDetailsToggleButton.IsChecked == true && ModDetailsRow.ActualHeight >= MinimumExpandedModDetailsRowHeight)
+		{
+			_lastExpandedModDetailsRowHeight = ModDetailsRow.ActualHeight;
+		}
+	}
+
+	private void UpdateModDetailsLayout(bool hasSelectedMod)
+	{
+		if (!hasSelectedMod)
+		{
+			ModDetailsGridSplitter.Visibility = Visibility.Collapsed;
+			ModDetailsSplitterRow.Height = new GridLength(0);
+			ModDetailsRow.MinHeight = 0;
+			ModDetailsRow.Height = new GridLength(0);
+			return;
+		}
+
+		if (ModDetailsToggleButton.IsChecked == false)
+		{
+			ModDetailsGridSplitter.Visibility = Visibility.Collapsed;
+			ModDetailsSplitterRow.Height = new GridLength(0);
+			ModDetailsRow.MinHeight = CollapsedModDetailsRowHeight;
+			ModDetailsRow.Height = new GridLength(CollapsedModDetailsRowHeight);
+			return;
+		}
+
+		ModDetailsGridSplitter.Visibility = Visibility.Visible;
+		ModDetailsSplitterRow.Height = new GridLength(ModDetailsSplitterHeight);
+		ModDetailsRow.MinHeight = MinimumExpandedModDetailsRowHeight;
+		ModDetailsRow.Height = new GridLength(Math.Max(MinimumExpandedModDetailsRowHeight, _lastExpandedModDetailsRowHeight));
+	}
+
+	private void ModDetailsToggleButton_Checked(object sender, RoutedEventArgs e)
+	{
+		UpdateModDetailsLayout(ModDetailsPanel.Visibility == Visibility.Visible);
+	}
+
+	private void ModDetailsToggleButton_Unchecked(object sender, RoutedEventArgs e)
+	{
+		RememberExpandedModDetailsHeight();
+		UpdateModDetailsLayout(ModDetailsPanel.Visibility == Visibility.Visible);
+	}
+
+	private void ModDetailsGridSplitter_DragCompleted(object sender, DragCompletedEventArgs e)
+	{
+		Dispatcher.BeginInvoke(new Action(RememberExpandedModDetailsHeight));
 	}
 
 	private IDisposable updatingActiveViewSelection;
@@ -477,6 +549,11 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 	public HorizontalModLayout()
 	{
 		InitializeComponent();
+		CaptureModListColumnWidths();
+
+		ModDetailsToggleButton.Checked += ModDetailsToggleButton_Checked;
+		ModDetailsToggleButton.Unchecked += ModDetailsToggleButton_Unchecked;
+		ModDetailsGridSplitter.DragCompleted += ModDetailsGridSplitter_DragCompleted;
 
 		SetupListView(ActiveModsListView);
 		SetupListView(InactiveModsListView);
@@ -541,6 +618,7 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 				}));
 
 				ViewModel.Layout = this;
+				ApplyModListColumnVisibility();
 
 				d(this.OneWayBind(ViewModel, vm => vm.ActiveMods, v => v.ActiveModsListView.ItemsSource));
 				d(this.OneWayBind(ViewModel, vm => vm.InactiveMods, v => v.InactiveModsListView.ItemsSource));
@@ -718,6 +796,223 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 		}
 	}
 
+	private IEnumerable<GridView> GetModListGridViews()
+	{
+		if (ActiveModsListView.View is GridView activeView)
+		{
+			yield return activeView;
+		}
+		if (ForceLoadedModsListView.View is GridView forceLoadedView)
+		{
+			yield return forceLoadedView;
+		}
+		if (InactiveModsListView.View is GridView inactiveView)
+		{
+			yield return inactiveView;
+		}
+	}
+
+	private static string GetColumnName(GridViewColumn column)
+	{
+		return column.Header switch
+		{
+			TextBlock textBlock => textBlock.Text,
+			string header => header,
+			_ => String.Empty
+		};
+	}
+
+	private void CaptureModListColumnWidths()
+	{
+		foreach (var gridView in GetModListGridViews())
+		{
+			foreach (var column in gridView.Columns)
+			{
+				if (!_visibleModListColumnWidths.ContainsKey(column))
+				{
+					_visibleModListColumnWidths[column] = column.Width;
+				}
+			}
+		}
+	}
+
+	private bool IsModListColumnVisible(string columnName)
+	{
+		if (ViewModel?.Settings == null)
+		{
+			return true;
+		}
+
+		return columnName switch
+		{
+			"Version" => ViewModel.Settings.ShowModListVersionColumn,
+			"Author" => ViewModel.Settings.ShowModListAuthorColumn,
+			"Last Updated" => ViewModel.Settings.ShowModListLastUpdatedColumn,
+			"Last Modified" => ViewModel.Settings.ShowModListLastModifiedColumn,
+			"Source" => ViewModel.Settings.ShowModListSourceColumn,
+			_ => true
+		};
+	}
+
+	private void SetModListColumnSetting(string columnName, bool isVisible)
+	{
+		if (ViewModel?.Settings == null)
+		{
+			return;
+		}
+
+		switch (columnName)
+		{
+			case "Version":
+				ViewModel.Settings.ShowModListVersionColumn = isVisible;
+				break;
+			case "Author":
+				ViewModel.Settings.ShowModListAuthorColumn = isVisible;
+				break;
+			case "Last Updated":
+				ViewModel.Settings.ShowModListLastUpdatedColumn = isVisible;
+				break;
+			case "Last Modified":
+				ViewModel.Settings.ShowModListLastModifiedColumn = isVisible;
+				break;
+			case "Source":
+				ViewModel.Settings.ShowModListSourceColumn = isVisible;
+				break;
+		}
+	}
+
+	private static double GetDefaultColumnWidth(string columnName)
+	{
+		return columnName switch
+		{
+			"Version" => 80,
+			"Author" => 100,
+			"Last Updated" => 100,
+			"Last Modified" => 100,
+			"Source" => 90,
+			_ => 100
+		};
+	}
+
+	private void SetGridViewColumnVisibility(GridView gridView, string columnName, bool isVisible)
+	{
+		var column = gridView.Columns.FirstOrDefault(candidate => GetColumnName(candidate) == columnName);
+		if (column == null)
+		{
+			return;
+		}
+
+		if (isVisible)
+		{
+			if (column.Width == 0)
+			{
+				column.Width = _visibleModListColumnWidths.TryGetValue(column, out var storedWidth)
+					? storedWidth
+					: GetDefaultColumnWidth(columnName);
+			}
+		}
+		else
+		{
+			if (column.Width != 0)
+			{
+				_visibleModListColumnWidths[column] = column.Width;
+				column.Width = 0;
+			}
+		}
+	}
+
+	private void ApplyModListColumnVisibility()
+	{
+		CaptureModListColumnWidths();
+		foreach (var gridView in GetModListGridViews())
+		{
+			foreach (var columnName in OptionalModListColumns)
+			{
+				SetGridViewColumnVisibility(gridView, columnName, IsModListColumnVisible(columnName));
+			}
+		}
+	}
+
+	private static MenuItem CreateFixedColumnMenuItem(string header)
+	{
+		return new MenuItem
+		{
+			Header = header,
+			IsCheckable = true,
+			IsChecked = true,
+			IsEnabled = false
+		};
+	}
+
+	private void ListViewColumnHeader_RightClick(object sender, MouseButtonEventArgs e)
+	{
+		if (sender is not ModListView listView || e.OriginalSource is not UIElement clickedElement)
+		{
+			return;
+		}
+
+		// The routed event is attached to the ListView, so row and empty-space clicks
+		// also reach this handler. Only open the chooser for a real column header.
+		var clickedHeader = clickedElement as GridViewColumnHeader
+			?? clickedElement.FindVisualParent<GridViewColumnHeader>();
+		if (clickedHeader == null)
+		{
+			return;
+		}
+
+		var menu = new ContextMenu
+		{
+			Placement = PlacementMode.MousePoint,
+			PlacementTarget = listView
+		};
+		menu.Items.Add(new MenuItem
+		{
+			Header = "Visible Columns",
+			FontWeight = FontWeights.SemiBold,
+			IsEnabled = false
+		});
+		menu.Items.Add(new Separator());
+
+		if (ReferenceEquals(listView, ActiveModsListView))
+		{
+			menu.Items.Add(CreateFixedColumnMenuItem("#  (load order — always shown)"));
+		}
+		menu.Items.Add(CreateFixedColumnMenuItem("Name  (always shown)"));
+
+		foreach (var columnName in OptionalModListColumns)
+		{
+			var item = new MenuItem
+			{
+				Header = columnName,
+				IsCheckable = true,
+				IsChecked = IsModListColumnVisible(columnName)
+			};
+			item.Click += (_, _) =>
+			{
+				SetModListColumnSetting(columnName, item.IsChecked);
+				ApplyModListColumnVisibility();
+				ViewModel.QueueSave();
+			};
+			menu.Items.Add(item);
+		}
+
+		menu.Items.Add(new Separator());
+		var resetItem = new MenuItem { Header = "Reset Columns" };
+		resetItem.Click += (_, _) =>
+		{
+			foreach (var columnName in OptionalModListColumns)
+			{
+				SetModListColumnSetting(columnName, true);
+			}
+			ApplyModListColumnVisibility();
+			ViewModel.QueueSave();
+		};
+		menu.Items.Add(resetItem);
+
+		menu.IsOpen = true;
+		e.Handled = true;
+	}
+
 	GridViewColumnHeader _lastHeaderClicked = null;
 	ListSortDirection _lastDirection = ListSortDirection.Ascending;
 
@@ -774,7 +1069,9 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 		if (sortBy == "#") sortBy = "Index";
 		if (sortBy == "Name") sortBy = "DisplayName";
 		if (sortBy == "Modes") sortBy = "Targets";
-		if (sortBy == "Last Updated") sortBy = "LastUpdated";
+		if (sortBy == "Last Updated") sortBy = "DisplayLastUpdated";
+		if (sortBy == "Last Modified") sortBy = "LastModified";
+		if (sortBy == "Source") sortBy = "DisplaySource";
 
 		try
 		{

--- a/src/GUI/Views/HorizontalModLayout.xaml.cs
+++ b/src/GUI/Views/HorizontalModLayout.xaml.cs
@@ -236,6 +236,22 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 		}
 	}
 
+	private DivinityModData GetSelectedModForDetails()
+	{
+		return ActiveModsListView.SelectedItems.OfType<DivinityModData>().LastOrDefault()
+			?? InactiveModsListView.SelectedItems.OfType<DivinityModData>().LastOrDefault()
+			?? ForceLoadedModsListView.SelectedItems.OfType<DivinityModData>().LastOrDefault();
+	}
+
+	private void UpdateModDetailsSelection(SelectionChangedEventArgs e)
+	{
+		var selectedMod = e?.AddedItems?.OfType<DivinityModData>().LastOrDefault()
+			?? GetSelectedModForDetails();
+
+		ModDetailsContent.Content = selectedMod;
+		ModDetailsPanel.Visibility = selectedMod != null ? Visibility.Visible : Visibility.Collapsed;
+	}
+
 	private IDisposable updatingActiveViewSelection;
 	private IDisposable updatingInactiveViewSelection;
 	private IDisposable updatingForcedViewSelection;
@@ -496,6 +512,7 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 				.Subscribe((e) =>
 				{
 					UpdateIsSelected(e.EventArgs, ViewModel.ActiveMods);
+					UpdateModDetailsSelection(e.EventArgs);
 				}));
 
 				d(Observable.FromEventPattern<SelectionChangedEventArgs>(InactiveModsListView, "SelectionChanged")
@@ -503,6 +520,7 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 				.Subscribe((e) =>
 				{
 					UpdateIsSelected(e.EventArgs, ViewModel.InactiveMods);
+					UpdateModDetailsSelection(e.EventArgs);
 				}));
 
 				d(Observable.FromEventPattern<SelectionChangedEventArgs>(ForceLoadedModsListView, "SelectionChanged")
@@ -510,6 +528,7 @@ public partial class HorizontalModLayout : HorizontalModLayoutBase, IModViewLayo
 				.Subscribe((e) =>
 				{
 					UpdateIsSelected(e.EventArgs, ViewModel.ForceLoadedMods);
+					UpdateModDetailsSelection(e.EventArgs);
 				}));
 
 				d(this.ViewModel.WhenAnyValue(x => x.OrderJustLoaded).ObserveOn(RxApp.MainThreadScheduler).Subscribe((b) =>

--- a/src/GUI/Views/MainViewControl.xaml
+++ b/src/GUI/Views/MainViewControl.xaml
@@ -701,7 +701,7 @@
 		</xc:BusyIndicator>
 		<StatusBar Grid.Row="1"
 			MinHeight="16"
-			Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+			Background="{DynamicResource ReduxWindowBrush}"
 			BorderBrush="{DynamicResource ReduxBorderBrush}"
 			BorderThickness="0,1,0,0"
 			Foreground="{DynamicResource ReduxTextSecondaryBrush}">

--- a/src/GUI/Views/MainViewControl.xaml
+++ b/src/GUI/Views/MainViewControl.xaml
@@ -29,15 +29,87 @@
 				<ResourceDictionary Source="../Themes/MainResourceDictionary.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 			<Style BasedOn="{StaticResource {x:Type Button}}" TargetType="{x:Type Button}" />
+			<ControlTemplate x:Key="ReduxDialogButtonTemplate" TargetType="{x:Type Button}">
+				<Border x:Name="ButtonChrome"
+					Padding="{TemplateBinding Padding}"
+					Background="{TemplateBinding Background}"
+					BorderBrush="{TemplateBinding BorderBrush}"
+					BorderThickness="{TemplateBinding BorderThickness}"
+					CornerRadius="6">
+					<ContentPresenter HorizontalAlignment="Center"
+						VerticalAlignment="Center"
+						Content="{TemplateBinding Content}"
+						ContentTemplate="{TemplateBinding ContentTemplate}"
+						RecognizesAccessKey="True" />
+				</Border>
+				<ControlTemplate.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+						<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+						<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+					</Trigger>
+					<Trigger Property="IsEnabled" Value="False">
+						<Setter TargetName="ButtonChrome" Property="Opacity" Value="0.45" />
+					</Trigger>
+				</ControlTemplate.Triggers>
+			</ControlTemplate>
+			<ControlTemplate x:Key="ReduxDialogPrimaryButtonTemplate" TargetType="{x:Type Button}">
+				<Border x:Name="ButtonChrome"
+					Padding="{TemplateBinding Padding}"
+					Background="{TemplateBinding Background}"
+					BorderBrush="{TemplateBinding BorderBrush}"
+					BorderThickness="{TemplateBinding BorderThickness}"
+					CornerRadius="6">
+					<ContentPresenter HorizontalAlignment="Center"
+						VerticalAlignment="Center"
+						Content="{TemplateBinding Content}"
+						ContentTemplate="{TemplateBinding ContentTemplate}"
+						RecognizesAccessKey="True" />
+				</Border>
+				<ControlTemplate.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxAccentHoverBrush}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+					</Trigger>
+					<Trigger Property="IsEnabled" Value="False">
+						<Setter TargetName="ButtonChrome" Property="Opacity" Value="0.45" />
+					</Trigger>
+				</ControlTemplate.Triggers>
+			</ControlTemplate>
+			<Style x:Key="ReduxDialogButtonStyle" TargetType="{x:Type Button}">
+				<Setter Property="Height" Value="30" />
+				<Setter Property="Padding" Value="14,4" />
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Template" Value="{StaticResource ReduxDialogButtonTemplate}" />
+			</Style>
+			<Style x:Key="ReduxDialogPrimaryButtonStyle" BasedOn="{StaticResource ReduxDialogButtonStyle}" TargetType="{x:Type Button}">
+				<Setter Property="Background" Value="{DynamicResource ReduxAccentBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxAccentHoverBrush}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxAccentForegroundBrush}" />
+				<Setter Property="Template" Value="{StaticResource ReduxDialogPrimaryButtonTemplate}" />
+			</Style>
 			<Style TargetType="{x:Type xc:MessageBox}">
 				<Setter Property="Width" Value="600" />
-				<Setter Property="Background" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer0BackgroundBrush}}" />
-				<Setter Property="ButtonRegionBackground" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer0BackgroundBrush}}" />
-				<Setter Property="BorderBrush" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer1BorderBrush}}" />
-				<Setter Property="CaptionForeground" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentForegroundBrush}}" />
-				<Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUI:Brushes.ForegroundBrush}}" />
-				<Setter Property="WindowBackground" Value="#4e38c9" />
-				<Setter Property="WindowBorderBrush" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBorderBrush}}" />
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceBrush}" />
+				<Setter Property="ButtonRegionBackground" Value="{DynamicResource ReduxSurfaceElevatedBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+				<Setter Property="CaptionForeground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="WindowBackground" Value="{DynamicResource ReduxSurfaceElevatedBrush}" />
+				<Setter Property="WindowBorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+				<Setter Property="WindowBorderThickness" Value="1" />
+				<Setter Property="YesButtonStyle" Value="{StaticResource ReduxDialogPrimaryButtonStyle}" />
+				<Setter Property="NoButtonStyle" Value="{StaticResource ReduxDialogButtonStyle}" />
+				<Setter Property="OkButtonStyle" Value="{StaticResource ReduxDialogPrimaryButtonStyle}" />
+				<Setter Property="CancelButtonStyle" Value="{StaticResource ReduxDialogButtonStyle}" />
 				<Setter Property="CloseButtonStyle">
 					<Setter.Value>
 						<Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
@@ -78,7 +150,7 @@
 			</Style>
 		</ResourceDictionary>
 	</UserControl.Resources>
-	<Grid>
+	<Grid Background="{DynamicResource ReduxWindowBrush}">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
@@ -135,14 +207,17 @@
 				    HorizontalAlignment="Stretch"
 				    VerticalAlignment="Stretch"
 				    Panel.ZIndex="98"
-				    Fill="{DynamicResource {x:Static adonisUI:Brushes.Layer3BackgroundBrush}}" />
-				<Grid Background="{DynamicResource {x:Static adonisUI:Brushes.Layer3BackgroundBrush}}">
+				    Fill="{DynamicResource ReduxWindowBrush}" />
+				<Grid Background="{DynamicResource ReduxWindowBrush}">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="*" />
 						<ColumnDefinition Width="Auto" />
 						<!--<ColumnDefinition Width="*" />-->
 					</Grid.ColumnDefinitions>
-					<Menu x:Name="TopMenuBar" Padding="2">
+					<Menu x:Name="TopMenuBar"
+						Padding="4,2"
+						Background="{DynamicResource ReduxWindowBrush}"
+						Foreground="{DynamicResource ReduxTextPrimaryBrush}">
 						<MenuItem x:Name="FileMenuItem" Header="File" />
 						<MenuItem x:Name="EditMenuItem" Header="Edit" />
 						<MenuItem x:Name="SettingsMenuItem" Header="Settings" />
@@ -292,7 +367,7 @@
 				</Grid>
 				<Separator Grid.Row="1"
 				    Height="1"
-				    Background="LightGray"
+				    Background="{DynamicResource ReduxBorderBrush}"
 				    BorderThickness="0" />
 				<Grid x:Name="ModOrderPanel" Grid.Row="2" Loaded="ModOrderPanel_Loaded">
 					<Grid.RowDefinitions>
@@ -300,29 +375,135 @@
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="*" />
 					</Grid.RowDefinitions>
-					<Grid Margin="4">
+					<Border Margin="10,8,10,10"
+					    Padding="10,8"
+					    Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+					    BorderBrush="{DynamicResource ReduxBorderBrush}"
+					    BorderThickness="1"
+					    CornerRadius="8">
+						<Grid>
 						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="Auto" />
 							<ColumnDefinition Width="Auto" />
 							<ColumnDefinition Width="Auto" />
 							<ColumnDefinition Width="*" />
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 						<Grid.Resources>
+							<ControlTemplate x:Key="ToolbarButtonTemplate" TargetType="{x:Type Button}">
+								<Border x:Name="ButtonChrome"
+									Padding="{TemplateBinding Padding}"
+									Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="6">
+									<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										Content="{TemplateBinding Content}"
+										ContentStringFormat="{TemplateBinding ContentStringFormat}"
+										ContentTemplate="{TemplateBinding ContentTemplate}"
+										RecognizesAccessKey="True" />
+								</Border>
+								<ControlTemplate.Triggers>
+									<Trigger Property="IsMouseOver" Value="True">
+										<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+										<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+									</Trigger>
+									<Trigger Property="IsPressed" Value="True">
+										<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+										<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+									</Trigger>
+									<Trigger Property="IsEnabled" Value="False">
+										<Setter TargetName="ButtonChrome" Property="Opacity" Value="0.45" />
+									</Trigger>
+								</ControlTemplate.Triggers>
+							</ControlTemplate>
+							<ControlTemplate x:Key="ToolbarPrimaryButtonTemplate" TargetType="{x:Type Button}">
+								<Border x:Name="ButtonChrome"
+									Padding="{TemplateBinding Padding}"
+									Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="6">
+									<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										Content="{TemplateBinding Content}"
+										ContentStringFormat="{TemplateBinding ContentStringFormat}"
+										ContentTemplate="{TemplateBinding ContentTemplate}"
+										RecognizesAccessKey="True" />
+								</Border>
+								<ControlTemplate.Triggers>
+									<Trigger Property="IsMouseOver" Value="True">
+										<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxAccentHoverBrush}" />
+									</Trigger>
+									<Trigger Property="IsPressed" Value="True">
+										<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+									</Trigger>
+									<Trigger Property="IsEnabled" Value="False">
+										<Setter TargetName="ButtonChrome" Property="Opacity" Value="0.45" />
+									</Trigger>
+								</ControlTemplate.Triggers>
+							</ControlTemplate>
 							<Style BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="TextBlock">
 								<Setter Property="VerticalAlignment" Value="Center" />
 								<Setter Property="Margin" Value="2,0,2,0" />
 							</Style>
 							<Style BasedOn="{StaticResource VerticalSeparator}" TargetType="Rectangle">
 								<Setter Property="Margin" Value="8,0,6,0" />
+								<Setter Property="Fill" Value="{DynamicResource ReduxBorderStrongBrush}" />
 							</Style>
-							<Style BasedOn="{StaticResource IconButtonStyle}" TargetType="{x:Type Button}">
+							<Style x:Key="ToolbarButtonBaseStyle" BasedOn="{StaticResource IconButtonStyle}" TargetType="{x:Type Button}">
+								<Setter Property="Width" Value="28" />
+								<Setter Property="Height" Value="30" />
+								<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+								<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+								<Setter Property="BorderThickness" Value="1" />
+								<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+								<Setter Property="HorizontalContentAlignment" Value="Center" />
+								<Setter Property="VerticalContentAlignment" Value="Center" />
+								<Setter Property="Template" Value="{StaticResource ToolbarButtonTemplate}" />
 								<Setter Property="Tag" Value="{Binding}" />
+							</Style>
+							<Style BasedOn="{StaticResource ToolbarButtonBaseStyle}" TargetType="{x:Type Button}" />
+							<Style BasedOn="{StaticResource {x:Type ComboBox}}" TargetType="{x:Type ComboBox}">
+								<Setter Property="MinHeight" Value="30" />
+								<Setter Property="Padding" Value="9,3" />
+								<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+								<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+								<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+								<Setter Property="adonisExtensions:CornerRadiusExtension.CornerRadius" Value="6" />
+							</Style>
+							<Style x:Key="ToolbarTextButtonStyle" BasedOn="{StaticResource ToolbarButtonBaseStyle}" TargetType="{x:Type Button}">
+								<Setter Property="Width" Value="Auto" />
+								<Setter Property="Height" Value="30" />
+								<Setter Property="Margin" Value="2,0,6,0" />
+								<Setter Property="Padding" Value="10,0" />
+								<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+								<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+								<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+								<Setter Property="BorderThickness" Value="1" />
+								<Setter Property="Tag" Value="{Binding}" />
+							</Style>
+							<Style x:Key="ToolbarPrimaryButtonStyle" BasedOn="{StaticResource ToolbarTextButtonStyle}" TargetType="{x:Type Button}">
+								<Setter Property="Background" Value="{DynamicResource ReduxAccentBrush}" />
+								<Setter Property="BorderBrush" Value="{DynamicResource ReduxAccentHoverBrush}" />
+								<Setter Property="Foreground" Value="{DynamicResource ReduxAccentForegroundBrush}" />
+								<Setter Property="Template" Value="{StaticResource ToolbarPrimaryButtonTemplate}" />
 							</Style>
 							<Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type ContextMenu}">
 								<Setter Property="DataContext" Value="{Binding RelativeSource={RelativeSource Mode=Self}, Path=PlacementTarget.Tag}" />
 							</Style>
 						</Grid.Resources>
-						<Grid>
+						<Button x:Name="ImportModButton"
+							Margin="0,0,10,0"
+							Style="{StaticResource ToolbarPrimaryButtonStyle}"
+							ToolTip="Install a Mod from an Archive">
+							<StackPanel Orientation="Horizontal">
+								<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource AddItemImage}" />
+								<TextBlock Text="Install Mod" />
+							</StackPanel>
+						</Button>
+						<Grid Grid.Column="1">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
@@ -345,7 +526,7 @@
 								</ComboBox.ContextMenu>
 							</ComboBox>
 						</Grid>
-						<Grid Grid.Column="1" Margin="4,0">
+						<Grid Grid.Column="2" Margin="4,0">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
@@ -377,7 +558,7 @@
 								</ComboBox.ContextMenu>
 							</ComboBox>
 						</Grid>
-						<Grid Grid.Column="2" Margin="1,0,0,0">
+						<Grid Grid.Column="3" Margin="1,0,0,0">
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="Auto" />
@@ -409,9 +590,13 @@
 							<Rectangle Grid.Column="1" Margin="8,0,6,0" Style="{StaticResource VerticalSeparator}" />
 							<StackPanel Grid.Column="2" Orientation="Horizontal">
 								<StackPanel.Resources />
-								<TextBlock Text="Export" />
-								<Button x:Name="ExportToModSettingsButton" ToolTip="Export Order to Game">
-									<controls:AutoGrayableImage Source="{StaticResource ExportScriptImage}" />
+								<Button x:Name="ExportToModSettingsButton"
+									Style="{StaticResource ToolbarTextButtonStyle}"
+									ToolTip="Export Order to Game">
+									<StackPanel Orientation="Horizontal">
+										<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource ExportScriptImage}" />
+										<TextBlock Text="Export to Game" />
+									</StackPanel>
 									<Button.ContextMenu>
 										<ContextMenu>
 											<MenuItem Command="{Binding Path=OpenFileCommand, Source={x:Static dapp:DivinityApp.Commands}}" CommandParameter="{Binding SelectedProfile.ModSettingsFile}" Header="Open Exported Mod Order File..." />
@@ -450,9 +635,13 @@
 									</ComboBox>
 								</StackPanel>
 								<Rectangle />
-								<TextBlock Text="Refresh" />
-								<Button x:Name="RefreshButton" ToolTip="Refresh Mods">
-									<controls:AutoGrayableImage Source="{StaticResource RefreshImage}" />
+								<Button x:Name="RefreshButton"
+									Style="{StaticResource ToolbarTextButtonStyle}"
+									ToolTip="Refresh Mods">
+									<StackPanel Orientation="Horizontal">
+										<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource RefreshImage}" />
+										<TextBlock Text="Refresh" />
+									</StackPanel>
 								</Button>
 								<Rectangle />
 								<TextBlock Text="Shortcuts" />
@@ -472,8 +661,13 @@
 										</ContextMenu>
 									</Button.ContextMenu>
 								</Button>
-								<Button x:Name="OpenGameButton" ToolTip="Launch Game">
-									<controls:AutoGrayableImage Source="{StaticResource OpenGameImage}" />
+								<Button x:Name="OpenGameButton"
+									Style="{StaticResource ToolbarTextButtonStyle}"
+									ToolTip="Launch Game">
+									<StackPanel Orientation="Horizontal">
+										<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource OpenGameImage}" />
+										<TextBlock Text="Launch Game" />
+									</StackPanel>
 									<Button.ContextMenu>
 										<ContextMenu>
 											<MenuItem Command="{Binding Path=OpenInFileExplorerCommand, Source={x:Static dapp:DivinityApp.Commands}}" CommandParameter="{Binding Settings.GameExecutablePath}" Header="Open Game Folder..." />
@@ -496,15 +690,21 @@
 								</Button>
 							</StackPanel>
 						</Grid>
-						<Grid Grid.Column="3" />
-					</Grid>
-					<Separator Grid.Row="1" Height="1" Background="{DynamicResource {x:Static adonisUI:Brushes.Layer3BorderBrush}}" />
+						<Grid Grid.Column="4" />
+						</Grid>
+					</Border>
+					<Separator Grid.Row="1" Height="1" Background="{DynamicResource ReduxBorderBrush}" />
 					<local:HorizontalModLayout x:Name="ModLayout" Grid.Row="2" />
 				</Grid>
-				<local:ModUpdatesLayout x:Name="ModUpdaterPanel" Grid.Row="2" Background="{DynamicResource {x:Static adonisUI:Brushes.Layer4BackgroundBrush}}" />
+				<local:ModUpdatesLayout x:Name="ModUpdaterPanel" Grid.Row="2" Background="{DynamicResource ReduxSurfaceBrush}" />
 			</Grid>
 		</xc:BusyIndicator>
-		<StatusBar Grid.Row="1" MinHeight="16">
+		<StatusBar Grid.Row="1"
+			MinHeight="16"
+			Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+			BorderBrush="{DynamicResource ReduxBorderBrush}"
+			BorderThickness="0,1,0,0"
+			Foreground="{DynamicResource ReduxTextSecondaryBrush}">
 			<StatusBarItem HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 				<controls:BusyIndicator x:Name="StatusBarBusyIndicator"
 				    Grid.Column="0"

--- a/src/GUI/Views/MainViewControl.xaml.cs
+++ b/src/GUI/Views/MainViewControl.xaml.cs
@@ -302,6 +302,7 @@ public partial class MainViewControl : MainViewControlViewBase
 
 		this.BindCommand(ViewModel, vm => vm.ToggleUpdatesViewCommand, view => view.UpdateViewToggleButton);
 
+		this.BindCommand(ViewModel, vm => vm.Keys.ImportMod.Command, view => view.ImportModButton);
 		this.BindCommand(ViewModel, vm => vm.Keys.Save.Command, view => view.SaveButton);
 		this.BindCommand(ViewModel, vm => vm.Keys.SaveAs.Command, view => view.SaveAsButton);
 		this.BindCommand(ViewModel, vm => vm.Keys.NewOrder.Command, view => view.AddNewOrderButton);

--- a/src/GUI/Views/MainWindow.xaml
+++ b/src/GUI/Views/MainWindow.xaml
@@ -21,7 +21,7 @@
     Width="1600"
     Height="800"
     d:DataContext="{d:DesignInstance Type=vm:MainWindowViewModel}"
-    TitleBarBackground="{DynamicResource ReduxSurfaceElevatedBrush}"
+    TitleBarBackground="{DynamicResource ReduxWindowBrush}"
     TitleBarForeground="{DynamicResource ReduxTextPrimaryBrush}"
     mc:Ignorable="d">
 	<Window.Style>
@@ -56,5 +56,22 @@
 	<Window.TaskbarItemInfo>
 		<TaskbarItemInfo />
 	</Window.TaskbarItemInfo>
-	<Grid x:Name="MainGrid" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+	<Grid x:Name="MainGrid" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+		<Border x:Name="WindowResizeGlow"
+			Margin="1"
+			Panel.ZIndex="1000"
+			Background="Transparent"
+			BorderBrush="{DynamicResource ReduxAccentHoverBrush}"
+			BorderThickness="2"
+			CornerRadius="6"
+			IsHitTestVisible="False"
+			Opacity="0">
+			<Border.Effect>
+				<DropShadowEffect BlurRadius="10"
+					Color="{DynamicResource ReduxAccentHoverColor}"
+					Opacity="0.75"
+					ShadowDepth="0" />
+			</Border.Effect>
+		</Border>
+	</Grid>
 </adonisControls:AdonisWindow>

--- a/src/GUI/Views/MainWindow.xaml
+++ b/src/GUI/Views/MainWindow.xaml
@@ -21,8 +21,8 @@
     Width="1600"
     Height="800"
     d:DataContext="{d:DesignInstance Type=vm:MainWindowViewModel}"
-    TitleBarBackground="#4e38c9"
-    TitleBarForeground="{DynamicResource {x:Static adonisUI:Brushes.AccentForegroundBrush}}"
+    TitleBarBackground="{DynamicResource ReduxSurfaceElevatedBrush}"
+    TitleBarForeground="{DynamicResource ReduxTextPrimaryBrush}"
     mc:Ignorable="d">
 	<Window.Style>
 		<Style BasedOn="{StaticResource {x:Type Window}}" TargetType="Window" />
@@ -40,8 +40,8 @@
 				<Setter Property="BorderBrush" Value="{DynamicResource {x:Static adonisUI:Brushes.Layer1BorderBrush}}" />
 				<Setter Property="CaptionForeground" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentForegroundBrush}}" />
 				<Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUI:Brushes.ForegroundBrush}}" />
-				<Setter Property="WindowBackground" Value="#4e38c9" />
-				<Setter Property="WindowBorderBrush" Value="{DynamicResource {x:Static adonisUI:Brushes.AccentInteractionBorderBrush}}" />
+				<Setter Property="WindowBackground" Value="{DynamicResource ReduxSurfaceElevatedBrush}" />
+				<Setter Property="WindowBorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
 				<Setter Property="CloseButtonStyle">
 					<Setter.Value>
 						<Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">

--- a/src/GUI/Views/MainWindow.xaml.cs
+++ b/src/GUI/Views/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media.Animation;
 
 using WpfScreenHelper;
 
@@ -189,6 +190,7 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainWindowViewModel>, I
 	}
 
 	private static IDisposable _saveWindowPositionTask = null;
+	private IDisposable _resizeGlowFadeTask = null;
 
 	private void SaveWindowSettings()
 	{
@@ -200,6 +202,30 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainWindowViewModel>, I
 	{
 		_saveWindowPositionTask?.Dispose();
 		_saveWindowPositionTask = RxApp.MainThreadScheduler.Schedule(TimeSpan.FromMilliseconds(500), SaveWindowSettings);
+	}
+
+	private void OnWindowResizeFeedback(object sender, SizeChangedEventArgs e)
+	{
+		if (!IsLoaded || WindowState == WindowState.Maximized)
+		{
+			WindowResizeGlow.Opacity = 0;
+			return;
+		}
+
+		WindowResizeGlow.BeginAnimation(OpacityProperty, null);
+		WindowResizeGlow.Opacity = 0.9;
+		_resizeGlowFadeTask?.Dispose();
+		_resizeGlowFadeTask = RxApp.MainThreadScheduler.Schedule(TimeSpan.FromMilliseconds(220), () =>
+		{
+			var fade = new DoubleAnimation
+			{
+				From = WindowResizeGlow.Opacity,
+				To = 0,
+				Duration = TimeSpan.FromMilliseconds(180),
+				FillBehavior = FillBehavior.HoldEnd
+			};
+			WindowResizeGlow.BeginAnimation(OpacityProperty, fade);
+		});
 	}
 
 	public void ApplyWindowPosition(WindowSettings win)
@@ -367,6 +393,7 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainWindowViewModel>, I
 	public MainWindow()
 	{
 		InitializeComponent();
+		SizeChanged += OnWindowResizeFeedback;
 		self = this;
 
 		_logsDir = DivinityApp.GetAppDirectory("_Logs");

--- a/src/GUI/Views/SettingsWindow.xaml
+++ b/src/GUI/Views/SettingsWindow.xaml
@@ -23,8 +23,8 @@
     Title="Preferences"
     Width="800"
     Height="900"
-    TitleBarBackground="#4e38c9"
-    TitleBarForeground="{DynamicResource {x:Static adonisUI:Brushes.AccentForegroundBrush}}"
+    TitleBarBackground="{DynamicResource ReduxSurfaceElevatedBrush}"
+    TitleBarForeground="{DynamicResource ReduxTextPrimaryBrush}"
     mc:Ignorable="d">
 	<Window.Style>
 		<Style BasedOn="{StaticResource {x:Type Window}}" TargetType="Window" />
@@ -34,6 +34,148 @@
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="../Themes/MainResourceDictionary.xaml" />
 			</ResourceDictionary.MergedDictionaries>
+			<ControlTemplate x:Key="SettingsActionButtonTemplate" TargetType="{x:Type Button}">
+				<Border x:Name="ButtonChrome"
+					Padding="{TemplateBinding Padding}"
+					Background="{TemplateBinding Background}"
+					BorderBrush="{TemplateBinding BorderBrush}"
+					BorderThickness="{TemplateBinding BorderThickness}"
+					CornerRadius="6">
+					<ContentPresenter HorizontalAlignment="Center"
+						VerticalAlignment="Center"
+						Content="{TemplateBinding Content}"
+						ContentTemplate="{TemplateBinding ContentTemplate}" />
+				</Border>
+				<ControlTemplate.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+						<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter TargetName="ButtonChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+						<Setter TargetName="ButtonChrome" Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+					</Trigger>
+					<Trigger Property="IsEnabled" Value="False">
+						<Setter TargetName="ButtonChrome" Property="Opacity" Value="0.45" />
+					</Trigger>
+				</ControlTemplate.Triggers>
+			</ControlTemplate>
+			<Style x:Key="SettingsActionButtonStyle" TargetType="{x:Type Button}">
+				<Setter Property="Height" Value="32" />
+				<Setter Property="Padding" Value="12,4" />
+				<Setter Property="Margin" Value="0,0,8,0" />
+				<Setter Property="Background" Value="{DynamicResource ReduxSurfaceMutedBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderStrongBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+				<Setter Property="Template" Value="{StaticResource SettingsActionButtonTemplate}" />
+			</Style>
+			<Style x:Key="SettingsTabControlStyle" TargetType="{x:Type TabControl}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="BorderThickness" Value="0" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type TabControl}">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="44" />
+									<RowDefinition Height="*" />
+								</Grid.RowDefinitions>
+								<Border Margin="12,0,12,6"
+									Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+									BorderBrush="{DynamicResource ReduxBorderBrush}"
+									BorderThickness="1"
+									CornerRadius="8">
+									<TabPanel Margin="6,4" IsItemsHost="True" />
+								</Border>
+								<Border Grid.Row="1"
+									Margin="12,0,12,12"
+									Background="{DynamicResource ReduxSurfaceBrush}"
+									BorderBrush="{DynamicResource ReduxBorderBrush}"
+									BorderThickness="1"
+									CornerRadius="8">
+									<ContentPresenter x:Name="PART_SelectedContentHost"
+										ContentSource="SelectedContent"
+										KeyboardNavigation.DirectionalNavigation="Contained"
+										TextElement.Foreground="{DynamicResource ReduxTextPrimaryBrush}" />
+								</Border>
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<Style x:Key="SettingsTabItemStyle" TargetType="{x:Type TabItem}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="BorderBrush" Value="Transparent" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="Cursor" Value="Hand" />
+				<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextSecondaryBrush}" />
+				<Setter Property="Margin" Value="0,0,4,0" />
+				<Setter Property="Padding" Value="12,6" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type TabItem}">
+							<Border x:Name="TabChrome"
+								Padding="{TemplateBinding Padding}"
+								Background="{TemplateBinding Background}"
+								BorderBrush="{TemplateBinding BorderBrush}"
+								BorderThickness="{TemplateBinding BorderThickness}"
+								CornerRadius="6">
+								<ContentPresenter HorizontalAlignment="Center"
+									VerticalAlignment="Center"
+									ContentSource="Header"
+									RecognizesAccessKey="True" />
+							</Border>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter TargetName="TabChrome" Property="Background" Value="{DynamicResource ReduxAccentSoftBrush}" />
+									<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+								</Trigger>
+								<Trigger Property="IsSelected" Value="True">
+									<Setter TargetName="TabChrome" Property="Background" Value="{DynamicResource ReduxSelectionBrush}" />
+									<Setter TargetName="TabChrome" Property="BorderBrush" Value="{DynamicResource ReduxAccentBrush}" />
+									<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+									<Setter Property="FontWeight" Value="SemiBold" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			<Style x:Key="SettingsPageTitleStyle" BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+				<Setter Property="FontSize" Value="20" />
+				<Setter Property="FontWeight" Value="Bold" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+			</Style>
+			<Style x:Key="SettingsPageDescriptionStyle" BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+				<Setter Property="Margin" Value="0,4,0,0" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextSecondaryBrush}" />
+				<Setter Property="TextWrapping" Value="Wrap" />
+			</Style>
+			<Style x:Key="SettingsSectionCardStyle" TargetType="{x:Type Border}">
+				<Setter Property="Margin" Value="0,14,0,0" />
+				<Setter Property="Padding" Value="16,14" />
+				<Setter Property="Background" Value="{DynamicResource ReduxListInteriorBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+				<Setter Property="BorderThickness" Value="1" />
+				<Setter Property="CornerRadius" Value="8" />
+			</Style>
+			<Style x:Key="SettingsSectionTitleStyle" BasedOn="{StaticResource {x:Type TextBlock}}" TargetType="{x:Type TextBlock}">
+				<Setter Property="FontSize" Value="13" />
+				<Setter Property="FontWeight" Value="SemiBold" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+			</Style>
+			<Style x:Key="SettingsWarningButtonStyle" BasedOn="{StaticResource SettingsActionButtonStyle}" TargetType="{x:Type Button}">
+				<Setter Property="Foreground" Value="{DynamicResource ReduxWarningBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxWarningBrush}" />
+			</Style>
+			<Style x:Key="SettingsListViewStyle" BasedOn="{StaticResource {x:Type ListView}}" TargetType="{x:Type ListView}">
+				<Setter Property="Background" Value="{DynamicResource ReduxListInteriorBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ReduxBorderBrush}" />
+				<Setter Property="BorderThickness" Value="0" />
+				<Setter Property="Foreground" Value="{DynamicResource ReduxTextPrimaryBrush}" />
+			</Style>
 			<controls:AutomationTooltip x:Key="ExtenderUpdateEntryToolTip" DataContext="{Binding RelativeSource={RelativeSource Mode=Self}, Path=PlacementTarget.Tag}">
 				<controls:AutomationTooltip.Resources>
 					<DataTemplate x:Key="RegularVersionTooltip">
@@ -114,35 +256,53 @@
 			</DataTemplate>
 		</ResourceDictionary>
 	</Window.Resources>
-	<Grid>
+	<Grid Background="{DynamicResource ReduxWindowBrush}">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
-		<Grid Margin="4">
+		<Border Margin="12,10,12,8"
+			Padding="10,8"
+			Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+			BorderBrush="{DynamicResource ReduxBorderBrush}"
+			BorderThickness="1"
+			CornerRadius="8">
+		<Grid>
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="2*" />
 				<ColumnDefinition Width="1*" />
 			</Grid.ColumnDefinitions>
 			<StackPanel Margin="0" HorizontalAlignment="Left" Orientation="Horizontal">
-				<Button x:Name="SaveSettingsButton" Style="{StaticResource IconButtonStyle}" ToolTip="Save Settings (CTRL + S)">
-					<controls:AutoGrayableImage Source="{StaticResource SaveImage}" />
+				<Button x:Name="SaveSettingsButton" Style="{StaticResource SettingsActionButtonStyle}" ToolTip="Save Settings (CTRL + S)">
+					<StackPanel Margin="0" Orientation="Horizontal">
+						<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource SaveImage}" />
+						<TextBlock Text="Save" />
+					</StackPanel>
 				</Button>
-				<Rectangle Margin="2,0" Style="{StaticResource VerticalSeparator}" />
-				<Button x:Name="OpenSettingsFolderButton" Style="{StaticResource IconButtonStyle}" ToolTip="Open Settings Folder">
-					<controls:AutoGrayableImage Source="{StaticResource OpenFolderImage}" />
+				<Button x:Name="OpenSettingsFolderButton" Style="{StaticResource SettingsActionButtonStyle}" ToolTip="Open Settings Folder">
+					<StackPanel Margin="0" Orientation="Horizontal">
+						<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource OpenFolderImage}" />
+						<TextBlock Text="Open Folder" />
+					</StackPanel>
 				</Button>
 			</StackPanel>
 			<Button x:Name="ResetSettingsButton"
-			    Grid.Column="2"
+			    Grid.Column="1"
 			    HorizontalAlignment="Right"
-			    Style="{StaticResource IconButtonStyle}">
-				<controls:AutoGrayableImage Source="{StaticResource DefaultIcon}" />
+			    Style="{StaticResource SettingsWarningButtonStyle}">
+				<StackPanel Margin="0" Orientation="Horizontal">
+					<controls:AutoGrayableImage Margin="0,0,6,0" Source="{StaticResource DefaultIcon}" />
+					<TextBlock Text="Reset" />
+				</StackPanel>
 			</Button>
 		</Grid>
+		</Border>
 
-		<TabControl x:Name="PreferencesTabControl" Grid.Row="1">
+		<TabControl x:Name="PreferencesTabControl"
+			Grid.Row="1"
+			ItemContainerStyle="{StaticResource SettingsTabItemStyle}"
+			Style="{StaticResource SettingsTabControlStyle}">
 			<TabItem x:Name="GeneralSettingssTab" FocusManager.FocusedElement="{Binding ElementName=SettingsAutoGrid}">
 				<TabItem.Header>
 					<TextBlock x:Name="GeneralSettingsTabHeader"
@@ -151,7 +311,29 @@
 					    ToolTip="Mod Manager Settings (Data/settings.json)" />
 				</TabItem.Header>
 				<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-					<controls:AutoGrid x:Name="SettingsAutoGrid" />
+					<Grid Margin="18,14">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<TextBlock Style="{StaticResource SettingsPageTitleStyle}" Text="General preferences" />
+						<TextBlock Grid.Row="1"
+							Style="{StaticResource SettingsPageDescriptionStyle}"
+							Text="Core mod manager behavior, paths, appearance, and everyday workflow." />
+						<Border Grid.Row="2" Style="{StaticResource SettingsSectionCardStyle}">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="1" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+								<TextBlock Style="{StaticResource SettingsSectionTitleStyle}" Text="Application behavior" />
+								<Border Grid.Row="1" Margin="0,10,0,0" Background="{DynamicResource ReduxBorderBrush}" />
+								<controls:AutoGrid x:Name="SettingsAutoGrid" Grid.Row="2" Margin="0,12,0,0" />
+							</Grid>
+						</Border>
+					</Grid>
 				</ScrollViewer>
 			</TabItem>
 			<TabItem x:Name="ScriptExtenderTab" FocusManager.FocusedElement="{Binding ElementName=ExtenderSettingsAutoGrid}">
@@ -161,15 +343,31 @@
 					    Text="Script Extender"
 					    ToolTip="Script Extender Settings (ScriptExtenderSettings.json)" />
 				</TabItem.Header>
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition Height="*" />
-						<RowDefinition Height="auto" />
-					</Grid.RowDefinitions>
-					<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-						<controls:AutoGrid x:Name="ExtenderSettingsAutoGrid" />
-					</ScrollViewer>
-				</Grid>
+				<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+					<Grid Margin="18,14">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<TextBlock Style="{StaticResource SettingsPageTitleStyle}" Text="Script Extender" />
+						<TextBlock Grid.Row="1"
+							Style="{StaticResource SettingsPageDescriptionStyle}"
+							Text="Configure Script Extender behavior without changing your installed mods or load order." />
+						<Border Grid.Row="2" Style="{StaticResource SettingsSectionCardStyle}">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="1" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+								<TextBlock Style="{StaticResource SettingsSectionTitleStyle}" Text="Extender behavior" />
+								<Border Grid.Row="1" Margin="0,10,0,0" Background="{DynamicResource ReduxBorderBrush}" />
+								<controls:AutoGrid x:Name="ExtenderSettingsAutoGrid" Grid.Row="2" Margin="0,12,0,0" />
+							</Grid>
+						</Border>
+					</Grid>
+				</ScrollViewer>
 			</TabItem>
 			<TabItem x:Name="ScriptExtenderUpdaterTab" FocusManager.FocusedElement="{Binding ElementName=ExtenderUpdaterSettingsAutoGrid}">
 				<TabItem.Header>
@@ -178,13 +376,27 @@
 					    Text="Updater"
 					    ToolTip="Script Extender Updater Settings (ScriptExtenderUpdaterConfig.json)" />
 				</TabItem.Header>
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition Height="*" />
-						<RowDefinition Height="auto" />
-					</Grid.RowDefinitions>
-					<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-						<controls:AutoGrid x:Name="ExtenderUpdaterSettingsAutoGrid">
+				<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+					<Grid Margin="18,14">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<TextBlock Style="{StaticResource SettingsPageTitleStyle}" Text="Extender updater" />
+						<TextBlock Grid.Row="1"
+							Style="{StaticResource SettingsPageDescriptionStyle}"
+							Text="Choose how Script Extender update information is retrieved and which version is targeted." />
+						<Border Grid.Row="2" Style="{StaticResource SettingsSectionCardStyle}">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="1" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+								<TextBlock Style="{StaticResource SettingsSectionTitleStyle}" Text="Update source and version" />
+								<Border Grid.Row="1" Margin="0,10,0,0" Background="{DynamicResource ReduxBorderBrush}" />
+								<controls:AutoGrid x:Name="ExtenderUpdaterSettingsAutoGrid" Grid.Row="2" Margin="0,12,0,0">
 							<TextBlock x:Name="UpdateChannelTextBlock"
 							    Grid.Column="0"
 							    behavior:TextBlockSettingsEntryAttributeBehavior.Property="UpdateChannel"
@@ -203,9 +415,11 @@
 							    Grid.Column="1"
 							    DisplayMemberPath="DisplayName"
 							    ToolTip="{StaticResource ExtenderUpdateEntryToolTip}" />
-						</controls:AutoGrid>
-					</ScrollViewer>
-				</Grid>
+								</controls:AutoGrid>
+							</Grid>
+						</Border>
+					</Grid>
+				</ScrollViewer>
 			</TabItem>
 			<TabItem x:Name="KeybindingsTabItem" FocusManager.FocusedElement="{Binding ElementName=KeybindingsListView}">
 				<TabItem.Header>
@@ -214,10 +428,25 @@
 					    Text="Keyboard Shortcuts"
 					    ToolTip="Mod Manager Settings (Data/keybindings.json)" />
 				</TabItem.Header>
-				<ListView x:Name="KeybindingsListView"
+				<Grid Margin="18,14">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<TextBlock Style="{StaticResource SettingsPageTitleStyle}" Text="Keyboard shortcuts" />
+					<TextBlock Grid.Row="1"
+						Style="{StaticResource SettingsPageDescriptionStyle}"
+						Text="Double-click a shortcut to edit it, or right-click for reset and remove options." />
+					<Border Grid.Row="2"
+						Padding="0"
+						ClipToBounds="True"
+						Style="{StaticResource SettingsSectionCardStyle}">
+						<ListView x:Name="KeybindingsListView"
 				    KeyboardNavigation.TabNavigation="Continue"
 				    MouseDoubleClick="HotkeyListViewItem_MouseDoubleClick"
-				    ScrollViewer.VerticalScrollBarVisibility="Auto">
+				    ScrollViewer.VerticalScrollBarVisibility="Auto"
+				    Style="{StaticResource SettingsListViewStyle}">
 					<ListView.ItemContainerStyle>
 						<Style BasedOn="{StaticResource {x:Type ListViewItem}}" TargetType="ListViewItem">
 							<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
@@ -247,7 +476,7 @@
 											    VerticalAlignment="Bottom"
 											    IsHitTestVisible="False"
 											    TextAlignment="Left">
-												<Run Foreground="Lime" Text="{Binding ModifiedText, Mode=OneWay}" />
+												<Run Foreground="{DynamicResource ReduxSuccessBrush}" Text="{Binding ModifiedText, Mode=OneWay}" />
 												<Run Text="{Binding DisplayName, Mode=OneWay}" /></TextBlock>
 										</DataTemplate>
 									</GridViewColumn.CellTemplate>
@@ -266,7 +495,9 @@
 							</GridView.Columns>
 						</GridView>
 					</ListView.View>
-				</ListView>
+						</ListView>
+					</Border>
+				</Grid>
 			</TabItem>
 			<TabItem x:Name="AdvancedSettingsTab" FocusManager.FocusedElement="{Binding ElementName=AdvancedSettingsAutoGrid}">
 				<TabItem.Header>
@@ -275,7 +506,28 @@
 					    Text="Advanced"
 					    ToolTip="Advanced Mod Manager Settings (Data/settings.json)" />
 				</TabItem.Header>
-				<controls:AutoGrid x:Name="AdvancedSettingsAutoGrid"
+				<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+					<Grid Margin="18,14">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<TextBlock Style="{StaticResource SettingsPageTitleStyle}" Text="Advanced tools" />
+						<TextBlock Grid.Row="1"
+							Style="{StaticResource SettingsPageDescriptionStyle}"
+							Text="Diagnostics, launch arguments, and maintenance options. Change these only when needed." />
+						<Border Grid.Row="2" Style="{StaticResource SettingsSectionCardStyle}">
+							<Grid>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="1" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+								<TextBlock Style="{StaticResource SettingsSectionTitleStyle}" Text="Diagnostics and launch behavior" />
+								<Border Grid.Row="1" Margin="0,10,0,0" Background="{DynamicResource ReduxBorderBrush}" />
+								<controls:AutoGrid x:Name="AdvancedSettingsAutoGrid"
+									Grid.Row="2"
 				    Margin="10,0"
 				    ChildMargin="8,4"
 				    ColumnCount="2"
@@ -290,6 +542,7 @@
 					<Button x:Name="GameLaunchParamsMainButton"
 					    VerticalAlignment="Center"
 					    Content="Launch Params"
+					    Style="{StaticResource SettingsActionButtonStyle}"
 					    ToolTip="Parameters to pass to the game executable when launching the game through the mod manager">
 						<Button.ContextMenu>
 							<ContextMenu x:Name="GameLaunchParamsMainMenu">
@@ -318,6 +571,9 @@
 						</Grid.ColumnDefinitions>
 						<TextBox x:Name="GameLaunchParamsTextBox"
 						    VerticalAlignment="Center"
+						    adonisExtensions:CornerRadiusExtension.CornerRadius="6"
+						    Background="{DynamicResource ReduxSurfaceMutedBrush}"
+						    BorderBrush="{DynamicResource ReduxBorderStrongBrush}"
 						    TextWrapping="Wrap"
 						    ToolTip="Parameters to pass to the game executable when launching the game through the mod manager" />
 						<Button x:Name="ClearLaunchParamsMenuItem"
@@ -332,11 +588,21 @@
 					    HorizontalAlignment="Center"
 					    VerticalAlignment="Center"
 					    Content="Delete Cache"
+					    Style="{StaticResource SettingsWarningButtonStyle}"
 					    ToolTip="Delete the local mod cache, located in the mod manager's Data folder" />
-				</controls:AutoGrid>
+								</controls:AutoGrid>
+							</Grid>
+						</Border>
+					</Grid>
+				</ScrollViewer>
 			</TabItem>
 		</TabControl>
-		<StatusBar Grid.Row="2" MinHeight="16">
+		<StatusBar Grid.Row="2"
+			MinHeight="16"
+			Background="{DynamicResource ReduxSurfaceElevatedBrush}"
+			BorderBrush="{DynamicResource ReduxBorderBrush}"
+			BorderThickness="0,1,0,0"
+			Foreground="{DynamicResource ReduxTextSecondaryBrush}">
 			<StatusBarItem HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 				<controls:AlertBar x:Name="AlertBar" Theme="Standard" />
 			</StatusBarItem>


### PR DESCRIPTION
## Big Redux checkpoint

This is basically my big safety checkpoint for BG3 Mod Manager Redux before I start migrating the old Nexus integration to API v3 and adding more advanced features.

My main goal with Redux is to make BG3MM feel cleaner, sleeker, and much easier to understand without breaking the mod manager functionality that already works. I am still learning C#, WPF, XAML, GitHub, and all of this as I go, so I am intentionally doing the overhaul in smaller, safer stages instead of trying to rewrite the whole program at once.

## What I have been working on

- A warmer plum/charcoal dark-mode design with purple accents
- Cleaner Active Mods and Inactive Mods panels
- A resizable selected-mod details drawer
- Overview, Media, Description, Requirements, Files, and Changelog tabs
- Automatic Nexus Mods metadata linking for the current development version
- Nexus cover images, descriptions, authors, versions, update dates, and changelogs
- Local and online metadata columns, including Source and Last Modified
- Optional columns that can be turned on and off from the header
- Better right-click menus for moving, opening, and deleting mods
- Cleaner dialogs, tooltips, notifications, splitters, title bars, and resize effects
- A changelog button that opens the actual Nexus Mods changelog page

## Things I am being careful not to break

The visual overhaul should not change the important backend behavior. This checkpoint does **not** intentionally rewrite:

- Mod load-order handling
- Import or export behavior
- LSLib usage
- BG3 path detection
- The actual installed mod files

The online metadata is only there to make mods easier to recognize and understand. The installed mod and its real BG3 load-order data are still the source of truth.

## What I tested

- The full Debug x64 solution builds with zero compiler errors
- Installing/importing mods
- Moving mods between Active and Inactive
- Drag-and-drop load-order movement
- Mod deletion and confirmation dialogs
- Column visibility controls
- Selecting mods and resizing/collapsing the details drawer
- Nexus metadata, images, descriptions, and changelogs
- Window and panel resizing

I also checked that API keys, local settings, cached metadata, generated binaries, and personal computer paths are not included in this PR.

## What comes next

The current Nexus support is based on the older integration inherited from BG3MM. My next major step is to build a shared metadata-provider system, migrate Nexus support to API v3, and then add mod.io as another source/fallback. After that I want to continue with categories, filters, separators, themes, and the larger Redux dashboard ideas.

I am keeping this PR as a draft because it is meant to be a recoverable foundation/checkpoint, not something I want to rush into the main branch yet.